### PR TITLE
Add JSON-LD schema markup to class and trial pages

### DIFF
--- a/Online-Hatha-Vinyasa-Classes.html
+++ b/Online-Hatha-Vinyasa-Classes.html
@@ -267,6 +267,30 @@
   <meta name="twitter:image" content="https://zugafitness.in/assets/images/photo-2025-03-07-22-31-00.jpg-192x190.jpg">
 
     <meta name="robots" content="index, follow">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Course",
+      "name": "Online Hatha & Vinyasa Yoga Classes",
+      "description": "Live Hatha and Vinyasa yoga classes online. Join from anywhere across all time zones.",
+      "provider": {
+        "@type": "Organization",
+        "name": "Zuga Fitness",
+        "sameAs": "https://zugafitness.in"
+      },
+      "offers": {
+        "@type": "Offer",
+        "price": "499",
+        "priceCurrency": "INR",
+        "availability": "https://schema.org/InStock"
+      },
+      "hasCourseInstance": {
+        "@type": "CourseInstance",
+        "courseMode": "Online",
+        "courseWorkload": "PT1H"
+      }
+    }
+    </script>
 </head>
 <body>
 

--- a/Online-Postpartum-Yoga-Classes.html
+++ b/Online-Postpartum-Yoga-Classes.html
@@ -267,6 +267,30 @@
   <meta name="twitter:image" content="https://zugafitness.in/assets/images/photo-2025-03-07-22-31-00.jpg-192x190.jpg">
 
     <meta name="robots" content="index, follow">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Course",
+      "name": "Online Postpartum Yoga Classes",
+      "description": "Gentle postpartum yoga classes online for new mothers. Expert-led recovery sessions from the comfort of home.",
+      "provider": {
+        "@type": "Organization",
+        "name": "Zuga Fitness",
+        "sameAs": "https://zugafitness.in"
+      },
+      "offers": {
+        "@type": "Offer",
+        "price": "499",
+        "priceCurrency": "INR",
+        "availability": "https://schema.org/InStock"
+      },
+      "hasCourseInstance": {
+        "@type": "CourseInstance",
+        "courseMode": "Online",
+        "courseWorkload": "PT1H"
+      }
+    }
+    </script>
 </head>
 <body>
 

--- a/Online-Pranayama-Classes.html
+++ b/Online-Pranayama-Classes.html
@@ -267,6 +267,30 @@
   <meta name="twitter:image" content="https://zugafitness.in/assets/images/photo-2025-03-07-22-31-00.jpg-192x190.jpg">
 
     <meta name="robots" content="index, follow">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Course",
+      "name": "Online Pranayama & Breathwork Classes",
+      "description": "Live online Pranayama classes with certified instructors. Breathing exercises for stress relief and wellness.",
+      "provider": {
+        "@type": "Organization",
+        "name": "Zuga Fitness",
+        "sameAs": "https://zugafitness.in"
+      },
+      "offers": {
+        "@type": "Offer",
+        "price": "499",
+        "priceCurrency": "INR",
+        "availability": "https://schema.org/InStock"
+      },
+      "hasCourseInstance": {
+        "@type": "CourseInstance",
+        "courseMode": "Online",
+        "courseWorkload": "PT1H"
+      }
+    }
+    </script>
 </head>
 <body>
 

--- a/Online-Yoga-Classes.html
+++ b/Online-Yoga-Classes.html
@@ -265,7 +265,30 @@
   <meta name="twitter:title" content="Online Yoga Classes for global community | Live Global Sessions | Zuga Fitness">
   <meta name="twitter:description" content="Join our live online yoga classes designed for the global Indian diaspora. Flexible time slots in EST, GMT, and GST. Expert instruction for all levels. Register now!">
   <meta name="twitter:image" content="https://zugafitness.in/assets/images/photo-2025-03-07-22-31-00.jpg-192x190.jpg">
-
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Course",
+    "name": "Online Yoga Classes",
+    "description": "Live online yoga classes across all time zones. Suitable for beginners to advanced practitioners.",
+    "provider": {
+      "@type": "Organization",
+      "name": "Zuga Fitness",
+      "sameAs": "https://zugafitness.in"
+    },
+    "offers": {
+      "@type": "Offer",
+      "price": "499",
+      "priceCurrency": "INR",
+      "availability": "https://schema.org/InStock"
+    },
+    "hasCourseInstance": {
+      "@type": "CourseInstance",
+      "courseMode": "Online",
+      "courseWorkload": "PT1H"
+    }
+  }
+  </script>
 </head>
 <body>
 

--- a/Virtual-Yoga-Classes.html
+++ b/Virtual-Yoga-Classes.html
@@ -51,7 +51,30 @@
   <meta name="twitter:title" content="Virtual Yoga Classes for global community | Live Global Studio | Zuga Fitness">
   <meta name="twitter:description" content="Interactive virtual yoga classes for global community. Join live sessions from US, UK, Canada & UAE. Flexible scheduling in global timezones. Start your journey today!">
   <meta name="twitter:image" content="https://zugafitness.in/assets/images/photo-2025-03-07-22-31-00.jpg-192x190.jpg">
-
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Course",
+    "name": "Virtual Yoga Classes",
+    "description": "Virtual yoga classes from home. Join live sessions with expert instructors across every time zone.",
+    "provider": {
+      "@type": "Organization",
+      "name": "Zuga Fitness",
+      "sameAs": "https://zugafitness.in"
+    },
+    "offers": {
+      "@type": "Offer",
+      "price": "499",
+      "priceCurrency": "INR",
+      "availability": "https://schema.org/InStock"
+    },
+    "hasCourseInstance": {
+      "@type": "CourseInstance",
+      "courseMode": "Online",
+      "courseWorkload": "PT1H"
+    }
+  }
+  </script>
 </head>
 <body>
 

--- a/free-trial.html
+++ b/free-trial.html
@@ -201,6 +201,22 @@
 
 
     <meta name="robots" content="index, follow">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Offer",
+      "name": "Free Trial Yoga Class",
+      "description": "Try a free online yoga class with Zuga Fitness. Live sessions across all time zones.",
+      "price": "0",
+      "priceCurrency": "INR",
+      "availability": "https://schema.org/InStock",
+      "url": "https://zugafitness.in/free-trial.html",
+      "seller": {
+        "@type": "Organization",
+        "name": "Zuga Fitness"
+      }
+    }
+    </script>
 </head>
 <body>
     <section data-bs-version="5.1" class="menu menu2 cid-uEEJbxSjp1" once="menu" id="menu-5-uEEJbxSjp1">


### PR DESCRIPTION
I have added JSON-LD schema markup to the following six HTML files as requested:
1. `free-trial.html` (Offer schema)
2. `Online-Yoga-Classes.html` (Course schema)
3. `Virtual-Yoga-Classes.html` (Course schema)
4. `Online-Hatha-Vinyasa-Classes.html` (Course schema)
5. `Online-Pranayama-Classes.html` (Course schema)
6. `Online-Postpartum-Yoga-Classes.html` (Course schema)

The schemas use `zugafitness.in` as the domain, as referenced from the existing JSON-LD in `index.html`. All scripts were inserted immediately before the closing `</head>` tag. I have also verified the syntax and structure of the added JSON-LD using a custom validation script.

---
*PR created automatically by Jules for task [15326838722214776309](https://jules.google.com/task/15326838722214776309) started by @ZugaFitness*