### PR TITLE
Add Trustpilot verification file

### DIFF
--- a/c40c0f38-15ce-4f48-b960-1636c9642946.html
+++ b/c40c0f38-15ce-4f48-b960-1636c9642946.html
@@ -1,0 +1,1 @@
+trustpilot-verification: c40c0f38-15ce-4f48-b960-1636c9642946


### PR DESCRIPTION
This PR adds the Trustpilot verification file `c40c0f38-15ce-4f48-b960-1636c9642946.html` to the root directory. 

The file contains the single line: `trustpilot-verification: c40c0f38-15ce-4f48-b960-1636c9642946`.

Key requirements met:
- Placed in the root directory.
- No HTML tags, headers, or body added.
- Exact text content as specified.

---
*PR created automatically by Jules for task [11963739272179624465](https://jules.google.com/task/11963739272179624465) started by @ZugaFitness*