### PR TITLE
Add Trustpilot domain verification meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta name="trustpilot-one-time-domain-verification-id" content="81d9e046-e582-4ca8-ad49-2aacb4f7de13"/>
   <!-- Site made with Mobirise Website Builder v6.0.1, https://mobirise.com -->
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
This change adds a one-time domain verification meta tag for Trustpilot to the head section of index.html. The tag is placed immediately after the opening head tag as requested.

---
*PR created automatically by Jules for task [16748572442363396437](https://jules.google.com/task/16748572442363396437) started by @ZugaFitness*