### PR TITLE
Fix Canonical Tags on All Blog Pages

### DIFF
--- a/Blog/Blog1.html
+++ b/Blog/Blog1.html
@@ -650,7 +650,7 @@
             }
         }
     </style>
-  <link rel="canonical" href="https://zugafitness.in/Blog/Blog1.html" />
+  <link rel="canonical" href="https://zugafitness.in/Blog/Blog1.html">
   <meta property="og:title" content="5 Morning Yoga Poses to Energize Your Day | Zuga Fitness Blog">
   <meta property="og:description" content="Start your day with these simple yet powerful yoga poses that boost energy, improve focus, and set a positive tone for your entire day | Zuga Fitness Blog">
   <meta property="og:image" content="https://zugafitness.in/assets/images/photo-2025-03-07-22-31-00.jpg-192x190.jpg">

--- a/Blog/Blog2.html
+++ b/Blog/Blog2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<link rel="canonical" href="https://zugafitness.in/Blog/yoga-for-stress-relief.html" />
+<link rel="canonical" href="https://zugafitness.in/Blog/Blog2.html">
 <meta http-equiv="refresh" content="0;url=yoga-for-stress-relief.html" />
 <script type="text/javascript">
 window.location.href = "yoga-for-stress-relief.html"

--- a/Blog/Blog3.html
+++ b/Blog/Blog3.html
@@ -710,7 +710,7 @@
             }
         }
     </style>
-  <link rel="canonical" href="https://zugafitness.in/Blog/Blog3.html" />
+  <link rel="canonical" href="https://zugafitness.in/Blog/Blog3.html">
   <meta property="og:title" content="Yoga for Better Sleep: 7 Poses to Improve Sleep Quality | Zuga Fitness Blog">
   <meta property="og:description" content="Discover scientifically-proven yoga poses to combat insomnia and achieve deep, restorative sleep naturally | Zuga Fitness Blog">
   <meta property="og:image" content="https://zugafitness.in/assets/images/photo-2025-03-07-22-31-00.jpg-192x190.jpg">

--- a/Blog/Blog4.html
+++ b/Blog/Blog4.html
@@ -666,7 +666,7 @@
             }
         }
     </style>
-  <link rel="canonical" href="https://zugafitness.in/Blog/Blog4.html" />
+  <link rel="canonical" href="https://zugafitness.in/Blog/Blog4.html">
   <meta property="og:title" content="Yoga for Hormonal Balance: Managing PCOS Naturally | Zuga Fitness Blog">
   <meta property="og:description" content="Specific yoga practices that can help regulate hormones and alleviate PCOS symptoms | Zuga Fitness Blog">
   <meta property="og:image" content="https://zugafitness.in/assets/images/photo-2025-03-07-22-31-00.jpg-192x190.jpg">

--- a/Blog/Blog5.html
+++ b/Blog/Blog5.html
@@ -590,7 +590,7 @@
             }
         }
     </style>
-  <link rel="canonical" href="https://zugafitness.in/Blog/Blog5.html" />
+  <link rel="canonical" href="https://zugafitness.in/Blog/Blog5.html">
   <meta property="og:title" content="Gentle Yoga for Seniors: Improving Mobility and Balance | Zuga Fitness Blog">
   <meta property="og:description" content="Yoga isn't just for the young and flexible. In fact, gentle yoga offers remarkable benefits for seniors looking to maintain their mobility, improve ba... | Zuga Fitness Blog">
   <meta property="og:image" content="https://zugafitness.in/assets/images/photo-2025-03-07-22-31-00.jpg-192x190.jpg">

--- a/Blog/Blog6.html
+++ b/Blog/Blog6.html
@@ -712,7 +712,7 @@
             }
         }
     </style>
-  <link rel="canonical" href="https://zugafitness.in/Blog/Blog6.html" />
+  <link rel="canonical" href="https://zugafitness.in/Blog/Blog6.html">
   <meta property="og:title" content="Yoga for Back Pain: 6 Poses to Relieve Discomfort | Zuga Fitness Blog">
   <meta property="og:description" content="Discover therapeutic yoga poses to alleviate back pain, strengthen your core, and improve spinal health | Zuga Fitness Blog">
   <meta property="og:image" content="https://zugafitness.in/assets/images/photo-2025-03-07-22-31-00.jpg-192x190.jpg">

--- a/Blog/How-long-yoga-takes-to-transform-your-body.html
+++ b/Blog/How-long-yoga-takes-to-transform-your-body.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<link rel="canonical" href="https://zugafitness.in/Blog/index.html" />
+<link rel="canonical" href="https://zugafitness.in/Blog/How-long-yoga-takes-to-transform-your-body.html">
 <meta http-equiv="refresh" content="0;url=index.html" />
 <script type="text/javascript">
 window.location.href = "index.html"

--- a/Blog/Yoga-Vs-Gym.html
+++ b/Blog/Yoga-Vs-Gym.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<link rel="canonical" href="https://zugafitness.in/Blog/index.html" />
+<link rel="canonical" href="https://zugafitness.in/Blog/Yoga-Vs-Gym.html">
 <meta http-equiv="refresh" content="0;url=index.html" />
 <script type="text/javascript">
 window.location.href = "index.html"

--- a/Blog/Yoga-for-stress-relief.html
+++ b/Blog/Yoga-for-stress-relief.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<link rel="canonical" href="https://zugafitness.in/Blog/yoga-for-stress-relief.html" />
+<link rel="canonical" href="https://zugafitness.in/Blog/Yoga-for-stress-relief.html">
 <meta http-equiv="refresh" content="0;url=yoga-for-stress-relief.html" />
 <script type="text/javascript">
 window.location.href = "yoga-for-stress-relief.html"

--- a/Blog/corporate-yoga-day-bangalore.html
+++ b/Blog/corporate-yoga-day-bangalore.html
@@ -579,7 +579,7 @@
             }
         }
     </style>
-  <link rel="canonical" href="https://zugafitness.in/Blog/corporate-yoga-day-bangalore.html" />
+  <link rel="canonical" href="https://zugafitness.in/Blog/corporate-yoga-day-bangalore.html">
 
   <script type="application/ld+json">
 {

--- a/Blog/hatha-vs-vinyasa-yoga.html
+++ b/Blog/hatha-vs-vinyasa-yoga.html
@@ -622,7 +622,7 @@
             }
         }
     </style>
-  <link rel="canonical" href="https://zugafitness.in/Blog/hatha-vs-vinyasa-yoga.html" />
+  <link rel="canonical" href="https://zugafitness.in/Blog/hatha-vs-vinyasa-yoga.html">
 
   <script type="application/ld+json">
 {

--- a/Blog/how-long-yoga-takes-to-transform-your-body.html
+++ b/Blog/how-long-yoga-takes-to-transform-your-body.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<link rel="canonical" href="https://zugafitness.in/Blog/index.html" />
+<link rel="canonical" href="https://zugafitness.in/Blog/how-long-yoga-takes-to-transform-your-body.html">
 <meta http-equiv="refresh" content="0;url=index.html" />
 <script type="text/javascript">
 window.location.href = "index.html"

--- a/Blog/index.html
+++ b/Blog/index.html
@@ -510,7 +510,7 @@
             }
         }
     </style>
-  <link rel="canonical" href="https://zugafitness.in/Blog/index.html" />
+  <link rel="canonical" href="https://zugafitness.in/Blog/index.html">
   <meta property="og:title" content="Yoga Blog | Zuga Fitness">
   <meta property="og:description" content="Join Zuga Fitness for live online yoga classes.">
   <meta property="og:image" content="../index.htmlassets/images/photo-2025-03-07-22-31-00.jpg-192x190.jpg">

--- a/Blog/live-vs-recorded-online-yoga-classes.html
+++ b/Blog/live-vs-recorded-online-yoga-classes.html
@@ -579,7 +579,7 @@
             }
         }
     </style>
-  <link rel="canonical" href="https://zugafitness.in/Blog/live-vs-recorded-online-yoga-classes.html" />
+  <link rel="canonical" href="https://zugafitness.in/Blog/live-vs-recorded-online-yoga-classes.html">
 
   <script type="application/ld+json">
 {

--- a/Blog/online-yoga-classes-canada-vancouver-toronto.html
+++ b/Blog/online-yoga-classes-canada-vancouver-toronto.html
@@ -579,7 +579,7 @@
             }
         }
     </style>
-  <link rel="canonical" href="https://zugafitness.in/Blog/online-yoga-classes-canada-vancouver-toronto.html" />
+  <link rel="canonical" href="https://zugafitness.in/Blog/online-yoga-classes-canada-vancouver-toronto.html">
 
   <script type="application/ld+json">
 {

--- a/Blog/online-yoga-classes-germany-berlin-munich.html
+++ b/Blog/online-yoga-classes-germany-berlin-munich.html
@@ -579,7 +579,7 @@
             }
         }
     </style>
-  <link rel="canonical" href="https://zugafitness.in/Blog/online-yoga-classes-germany-berlin-munich.html" />
+  <link rel="canonical" href="https://zugafitness.in/Blog/online-yoga-classes-germany-berlin-munich.html">
 
   <script type="application/ld+json">
 {

--- a/Blog/online-yoga-classes-malaysia-kuala-lumpur-penang.html
+++ b/Blog/online-yoga-classes-malaysia-kuala-lumpur-penang.html
@@ -579,7 +579,7 @@
             }
         }
     </style>
-  <link rel="canonical" href="https://zugafitness.in/Blog/online-yoga-classes-malaysia-kuala-lumpur-penang.html" />
+  <link rel="canonical" href="https://zugafitness.in/Blog/online-yoga-classes-malaysia-kuala-lumpur-penang.html">
 
   <script type="application/ld+json">
 {

--- a/Blog/online-yoga-for-back-pain.html
+++ b/Blog/online-yoga-for-back-pain.html
@@ -579,7 +579,7 @@
             }
         }
     </style>
-  <link rel="canonical" href="https://zugafitness.in/Blog/online-yoga-for-back-pain.html" />
+  <link rel="canonical" href="https://zugafitness.in/Blog/online-yoga-for-back-pain.html">
 
   <meta property="og:title" content="Online Yoga for Back Pain: 6 Poses Your Spine Needs Right Now | Zuga Fitness" />
   <meta property="og:description" content="Chronic back pain from sitting all day? These 6 yoga poses target the exact muscles desk work damages — and you can do them in 20 minutes at home." />

--- a/Blog/pranayama-for-anxiety.html
+++ b/Blog/pranayama-for-anxiety.html
@@ -579,7 +579,7 @@
             }
         }
     </style>
-  <link rel="canonical" href="https://zugafitness.in/Blog/pranayama-for-anxiety.html" />
+  <link rel="canonical" href="https://zugafitness.in/Blog/pranayama-for-anxiety.html">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="article">

--- a/Blog/yoga-for-back-pain-relief.html
+++ b/Blog/yoga-for-back-pain-relief.html
@@ -579,7 +579,7 @@
             }
         }
     </style>
-  <link rel="canonical" href="https://zugafitness.in/Blog/yoga-for-back-pain-relief.html" />
+  <link rel="canonical" href="https://zugafitness.in/Blog/yoga-for-back-pain-relief.html">
 
   <script type="application/ld+json">
 {

--- a/Blog/yoga-for-corporate-professionals.html
+++ b/Blog/yoga-for-corporate-professionals.html
@@ -579,7 +579,7 @@
             }
         }
     </style>
-  <link rel="canonical" href="https://zugafitness.in/Blog/yoga-for-corporate-professionals.html" />
+  <link rel="canonical" href="https://zugafitness.in/Blog/yoga-for-corporate-professionals.html">
   <meta property="og:title" content="Yoga for Corporate Professionals: 30-Minute Desk-to-Mat Sequence | Zuga Fitness">
   <meta property="og:description" content="Desk work doing damage to your body? This 30-minute yoga sequence for corporate professionals targets back pain, hip tightness, and mental stress.">
   <meta property="og:image" content="https://images.unsplash.com/photo-1588282322673-c31965a75c3e?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80">

--- a/Blog/yoga-for-stress-relief.html
+++ b/Blog/yoga-for-stress-relief.html
@@ -687,7 +687,7 @@
             }
         }
     </style>
-  <link rel="canonical" href="https://zugafitness.in/Blog/yoga-for-stress-relief.html" />
+  <link rel="canonical" href="https://zugafitness.in/Blog/yoga-for-stress-relief.html">
   <meta property="og:title" content="The Science Behind Yoga and Stress Reduction | Zuga Fitness Blog">
   <meta property="og:description" content="Discover how yoga physically changes your body's stress response and promotes relaxation at a cellular level | Zuga Fitness Blog">
   <meta property="og:image" content="https://zugafitness.in/assets/images/photo-2025-03-07-22-31-00.jpg-192x190.jpg">

--- a/Blog/yoga-poses-for-better-sleep.html
+++ b/Blog/yoga-poses-for-better-sleep.html
@@ -579,7 +579,7 @@
             }
         }
     </style>
-    <link rel="canonical" href="https://zugafitness.in/Blog/yoga-poses-for-better-sleep.html" />
+    <link rel="canonical" href="https://zugafitness.in/Blog/yoga-poses-for-better-sleep.html">
 
     <script type="application/ld+json">
     {

--- a/Blog/yoga-vs-gym.html
+++ b/Blog/yoga-vs-gym.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<link rel="canonical" href="https://zugafitness.in/Blog/index.html" />
+<link rel="canonical" href="https://zugafitness.in/Blog/yoga-vs-gym.html">
 <meta http-equiv="refresh" content="0;url=index.html" />
 <script type="text/javascript">
 window.location.href = "index.html"


### PR DESCRIPTION
I have updated every file in the `Blog/` folder to ensure it has a correct, self-referencing canonical tag. 

Key changes:
- Every page now has: `<link rel="canonical" href="https://zugafitness.in/Blog/[filename].html">`.
- Redirect stubs (like `Blog2.html` or `Yoga-Vs-Gym.html`) that were previously pointing their canonical tag to a new page or the index have been corrected to be self-referencing as per your specific instruction.
- The format has been standardized across all 31 blog files to use the exact syntax provided in your prompt.

I have verified these changes using a validation script and confirmed that no other content was altered.

---
*PR created automatically by Jules for task [1921133957743037886](https://jules.google.com/task/1921133957743037886) started by @ZugaFitness*