### PR TITLE
Remove personal information from instructor portfolios

### DIFF
--- a/Anusha Portfolio.html
+++ b/Anusha Portfolio.html
@@ -756,20 +756,6 @@
                 <h2>Yoga Therapist & Dance Instructor</h2>
             </div>
 
-            <div class="contact-header">
-                <div class="contact-item">
-                    <i class="fas fa-phone"></i>
-                    <span>7022207304</span>
-                </div>
-                <div class="contact-item">
-                    <i class="fas fa-envelope"></i>
-                    <span>anushaypatroti19@gmail.com</span>
-                </div>
-                <div class="contact-item">
-                    <i class="fas fa-map-marker-alt"></i>
-                    <span>Hubli, Karnataka</span>
-                </div>
-            </div>
 
             <p style="font-size: 1.2rem; max-width: 700px; margin: 0 auto; opacity: 0.9;">
                 Creating transformative experiences through personalized yoga instruction and movement therapy
@@ -785,44 +771,8 @@
             </div>
             <div class="about-content">
                 <div class="about-text">
-                    <h3>Career Objective</h3>
+                    <h3>About Anusha</h3>
                     <p>To leverage my passion for yoga and extensive training as a yoga instructor to create a transformative experience for students. I aim to guide and inspire individuals of all levels, fostering physical and mental well-being through personalized instruction, while cultivating a supportive and inclusive environment that promotes self-awareness, growth, and inner balance.</p>
-
-                    <div class="personal-info">
-                        <h3>Personal Information</h3>
-                        <div class="info-grid">
-                            <div class="info-item">
-                                <i class="fas fa-birthday-cake"></i>
-                                <div>
-                                    <strong>Date of Birth:</strong> 19-Feb-2000
-                                </div>
-                            </div>
-                            <div class="info-item">
-                                <i class="fas fa-user"></i>
-                                <div>
-                                    <strong>Gender:</strong> Female
-                                </div>
-                            </div>
-                            <div class="info-item">
-                                <i class="fas fa-flag"></i>
-                                <div>
-                                    <strong>Nationality:</strong> Indian
-                                </div>
-                            </div>
-                            <div class="info-item">
-                                <i class="fas fa-heart"></i>
-                                <div>
-                                    <strong>Marital Status:</strong> Unmarried
-                                </div>
-                            </div>
-                            <div class="info-item">
-                                <i class="fas fa-language"></i>
-                                <div>
-                                    <strong>Languages:</strong> English, Hindi, Kannada
-                                </div>
-                            </div>
-                        </div>
-                    </div>
                 </div>
                 <div class="yoga-dance-image"></div>
             </div>
@@ -1086,26 +1036,6 @@
     <!-- Footer -->
     <footer>
         <div class="container">
-            <div class="declaration">
-                <p>Experienced yoga instructor dedicated to creating a nurturing environment, promoting physical and mental well-being through personalized yoga sessions. Committed to continuous learning and building a supportive community. All the information mentioned in the resume are correct to the best of my knowledge and belief.</p>
-                <p style="margin-top: 15px; font-weight: 500;">- Anusha Y Patroti</p>
-            </div>
-
-            <div class="contact-info">
-                <div class="contact-item">
-                    <i class="fas fa-phone"></i>
-                    <span>7022207304</span>
-                </div>
-                <div class="contact-item">
-                    <i class="fas fa-envelope"></i>
-                    <span>anushaypatroti19@gmail.com</span>
-                </div>
-                <div class="contact-item">
-                    <i class="fas fa-map-marker-alt"></i>
-                    <span>#316 Siddramnagar Gopanakoppa Hublif-580023</span>
-                </div>
-            </div>
-
             <div class="social-links">
                 <a href="#"><i class="fab fa-instagram"></i></a>
                 <a href="#"><i class="fab fa-facebook"></i></a>
@@ -1114,7 +1044,7 @@
             </div>
 
             <div class="copyright">
-                <p>&copy; 2023 Anusha Y Patroti | Yoga Therapist & Dance Instructor</p>
+                <p>&copy; 2025 Zuga Fitness</p>
             </div>
         </div>
     </footer>

--- a/Mallinath Portfolio.html
+++ b/Mallinath Portfolio.html
@@ -683,44 +683,8 @@
             </div>
             <div class="about-content">
                 <div class="about-text">
-                    <h3>Career Objective</h3>
+                    <h3>About Mallinath</h3>
                     <p>Dedicated and certified yoga therapist with extensive experience in yoga teaching and a passion for holistic wellness, aiming to combine my background in mindfulness and body awareness with a commitment to fostering a supportive and inclusive environment that empowers individuals of all levels to achieve their wellness goals through personalized classes that blend the principles of yoga.</p>
-
-                    <div class="personal-info">
-                        <h3>Personal Information</h3>
-                        <div class="info-grid">
-                            <div class="info-item">
-                                <i class="fas fa-birthday-cake"></i>
-                                <div>
-                                    <strong>Date of Birth:</strong> 21-Dec-1999
-                                </div>
-                            </div>
-                            <div class="info-item">
-                                <i class="fas fa-user"></i>
-                                <div>
-                                    <strong>Gender:</strong> Male
-                                </div>
-                            </div>
-                            <div class="info-item">
-                                <i class="fas fa-flag"></i>
-                                <div>
-                                    <strong>Nationality:</strong> Indian
-                                </div>
-                            </div>
-                            <div class="info-item">
-                                <i class="fas fa-heart"></i>
-                                <div>
-                                    <strong>Marital Status:</strong> Unmarried
-                                </div>
-                            </div>
-                            <div class="info-item">
-                                <i class="fas fa-language"></i>
-                                <div>
-                                    <strong>Languages:</strong> Kannada, Hindi, English
-                                </div>
-                            </div>
-                        </div>
-                    </div>
                 </div>
                 <div class="yoga-image"></div>
             </div>
@@ -953,28 +917,8 @@
     <!-- Footer -->
     <footer>
         <div class="container">
-            <div class="declaration">
-                <p>I hereby declare that the information mentioned above is correct to the best of my knowledge and I bear the responsibility for the correctness of the mentioned particulars.</p>
-                <p style="margin-top: 15px; font-weight: 500;">- Mallinath B Beelur</p>
-            </div>
-
-            <div class="contact-info">
-                <div class="contact-item">
-                    <i class="fas fa-envelope"></i>
-                    <span>contact@mallinathyoga.com</span>
-                </div>
-                <div class="contact-item">
-                    <i class="fas fa-phone"></i>
-                    <span>+91 9876543210</span>
-                </div>
-                <div class="contact-item">
-                    <i class="fas fa-map-marker-alt"></i>
-                    <span>Karnataka, India</span>
-                </div>
-            </div>
-
             <div class="copyright">
-                <p>&copy; 2023 Mallinath B Beelur | Yoga Therapist & Wellness Coach</p>
+                <p>&copy; 2025 Zuga Fitness</p>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
This PR removes sensitive personal information from the portfolio pages of Mallinath B Beelur and Anusha Y Patroti to ensure privacy and professional alignment with Zuga Fitness branding. 

Key changes:
1.  **Privacy Removal**: Deleted sections containing DOB, marital status, nationality, personal phone numbers, and private email addresses.
2.  **Professionalism**: Removed the "Career Objective" heading (renamed to "About [Name]") and the CV-style declaration statements.
3.  **Branding**: Updated the copyright year and entity to "© 2025 Zuga Fitness".
4.  **Verification**: Verified using `grep` to ensure no sensitive strings remain and visual screenshots to confirm layout integrity.

All changes strictly follow the user's instructions to preserve styling and existing professional achievements.

---
*PR created automatically by Jules for task [5336039576215013334](https://jules.google.com/task/5336039576215013334) started by @ZugaFitness*