### PR TITLE
Update hero illustrations on service pages with Unsplash images

### DIFF
--- a/Online-Personal-Training-classes.html
+++ b/Online-Personal-Training-classes.html
@@ -259,13 +259,9 @@
         </div>
       </div>
       <div class="col-md-6 text-center lottie-container">
-        <lottie-player
-          src="https://assets10.lottiefiles.com/packages/lf20_yd8fbnml.json"
-          background="transparent"
-          speed="1"
-          style="width:100%;max-width:480px;height:480px;"
-          loop autoplay>
-        </lottie-player>
+        <img src="https://images.unsplash.com/photo-1518611012118-696072aa579a?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80"
+             alt="Personal yoga training session online"
+             style="width:100%;max-width:100%;height:auto;border-radius:12px;object-fit:cover;">
       </div>
     </div>
   </div>

--- a/Online-Pranayama-Classes.html
+++ b/Online-Pranayama-Classes.html
@@ -295,13 +295,9 @@
         </div>
       </div>
       <div class="col-md-6 text-center lottie-container">
-        <lottie-player
-          src="https://assets9.lottiefiles.com/packages/lf20_uu0x8lqv.json"
-          background="transparent"
-          speed="0.8"
-          style="width:100%;max-width:480px;height:480px;"
-          loop autoplay>
-        </lottie-player>
+        <img src="https://images.unsplash.com/photo-1506126613408-eca07ce68773?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80"
+             alt="Pranayama and meditation breathing practice"
+             style="width:100%;max-width:100%;height:auto;border-radius:12px;object-fit:cover;">
       </div>
     </div>
   </div>

--- a/Online-Yoga-Classes-For-PCOD.html
+++ b/Online-Yoga-Classes-For-PCOD.html
@@ -311,13 +311,9 @@
         </div>
       </div>
       <div class="col-md-6 text-center lottie-container">
-        <lottie-player
-          src="https://assets3.lottiefiles.com/packages/lf20_yd8fbnml.json"
-          background="transparent"
-          speed="0.8"
-          style="width:100%;max-width:480px;height:480px;"
-          loop autoplay>
-        </lottie-player>
+        <img src="https://images.unsplash.com/photo-1544367567-0f2fcb009e0b?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80"
+             alt="Yoga for PCOD and women's wellness"
+             style="width:100%;max-width:100%;height:auto;border-radius:12px;object-fit:cover;">
       </div>
     </div>
   </div>

--- a/Online-Yoga-Classes.html
+++ b/Online-Yoga-Classes.html
@@ -288,9 +288,9 @@
         </div>
       </div>
       <div class="col-md-6 text-center">
-        <div class="hero-image">
-          <!-- Placeholder for image 500x650 -->
-        </div>
+        <img src="https://images.unsplash.com/photo-1599901860904-17e6ed7083a0?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80"
+             alt="Live online group yoga class on Zoom"
+             style="width:100%;max-width:100%;height:auto;border-radius:12px;object-fit:cover;">
       </div>
     </div>
   </div>


### PR DESCRIPTION
I have updated the hero sections of four service pages to use relevant Unsplash yoga images instead of Lottie animations. 

### Changes:
1.  **Online-Yoga-Classes.html**: Replaced a placeholder div with a live group yoga class image.
2.  **Online-Personal-Training-classes.html**: Replaced the hero Lottie with a personal training session image.
3.  **Online-Pranayama-Classes.html**: Replaced the hero Lottie with a breathing practice image.
4.  **Online-Yoga-Classes-For-PCOD.html**: Replaced the hero Lottie with a women's wellness yoga image.

### Technical Details:
- **Responsiveness**: All new `<img>` tags include the style `width:100%; max-width:100%; height:auto; border-radius:12px; object-fit:cover;` as requested.
- **Script Cleanup**: I analyzed all target files for remaining Lottie animations. 
    - `Online-Yoga-Classes.html` has no Lotties and no script tag.
    - The other three files (`Online-Personal-Training-classes.html`, `Online-Pranayama-Classes.html`, and `Online-Yoga-Classes-For-PCOD.html`) contain secondary Lottie animations in their "What to Expect" sections, so the `lottie-player` script tag was correctly retained in those files.
- **Verification**: Changes were visually verified using Playwright screenshots.
- **Hygiene**: Removed `server.log` and the `verification/` folder before submission.

---
*PR created automatically by Jules for task [14114097437318957350](https://jules.google.com/task/14114097437318957350) started by @ZugaFitness*