### PR TITLE
Fix file naming mismatches and metadata for Zumba and Portfolio pages

### DIFF
--- a/Mallinath-Portfolio.html
+++ b/Mallinath-Portfolio.html
@@ -631,11 +631,11 @@
             }
         }
     </style>
-  <link rel="canonical" href="https://zugafitness.in/Mallinath%20Portfolio.html" />
+  <link rel="canonical" href="https://zugafitness.in/Mallinath-Portfolio.html" />
   <meta property="og:title" content="Mallinath — Yoga Instructor at Zuga Fitness">
   <meta property="og:description" content="Meet Mallinath, a certified yoga instructor at Zuga Fitness. Specializing in holistic wellness and personalized practice. Book a class with Mallinath today.">
   <meta property="og:image" content="https://zugafitness.in/assets/images/photo-2025-03-07-22-31-00.jpg-192x190.jpg">
-  <meta property="og:url" content="https://zugafitness.in/Mallinath Portfolio.html">
+  <meta property="og:url" content="https://zugafitness.in/Mallinath-Portfolio.html">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Zuga Fitness">
   <meta name="twitter:card" content="summary_large_image">

--- a/Yoga-Classes-In-Bangalore/Apartment-Zumba.html
+++ b/Yoga-Classes-In-Bangalore/Apartment-Zumba.html
@@ -569,11 +569,11 @@
             }
         }
     </style>
-  <link rel="canonical" href="https://zugafitness.in/Yoga-Classes-In-Bangalore/Apartment%20Zumba.html" />
+  <link rel="canonical" href="https://zugafitness.in/Yoga-Classes-In-Bangalore/Apartment-Zumba.html" />
   <meta property="og:title" content="Zuga Fitness - Apartment Zumba Classes">
   <meta property="og:description" content="Join Zuga Fitness for live online yoga classes.">
   <meta property="og:image" content="https://zugafitness.in/assets/images/photo-2025-03-07-22-31-00.jpg-192x190.jpg">
-  <meta property="og:url" content="https://zugafitness.in/Yoga-Classes-In-Bangalore/Apartment Zumba.html">
+  <meta property="og:url" content="https://zugafitness.in/Yoga-Classes-In-Bangalore/Apartment-Zumba.html">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Zuga Fitness">
   <meta name="twitter:card" content="summary_large_image">

--- a/Yoga-Classes-In-Bangalore/Corporate-Zumba.html
+++ b/Yoga-Classes-In-Bangalore/Corporate-Zumba.html
@@ -416,11 +416,11 @@
             }
         }
     </style>
-  <link rel="canonical" href="https://zugafitness.in/Yoga-Classes-In-Bangalore/Corporate%20Zumba.html" />
+  <link rel="canonical" href="https://zugafitness.in/Yoga-Classes-In-Bangalore/Corporate-Zumba.html" />
   <meta property="og:title" content="Rhythm & Move | Zumba Session Booking">
   <meta property="og:description" content="Join Zuga Fitness for live online yoga classes.">
   <meta property="og:image" content="https://zugafitness.in/assets/images/photo-2025-03-07-22-31-00.jpg-192x190.jpg">
-  <meta property="og:url" content="https://zugafitness.in/Yoga-Classes-In-Bangalore/Corporate Zumba.html">
+  <meta property="og:url" content="https://zugafitness.in/Yoga-Classes-In-Bangalore/Corporate-Zumba.html">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Zuga Fitness">
   <meta name="twitter:card" content="summary_large_image">

--- a/index.html
+++ b/index.html
@@ -903,7 +903,7 @@
                         <img loading="lazy" src="assets/images/photo-2025-03-08-15-59-42.jpg-518x921.jpeg" alt="Fitness Coach" title="" data-slide-to="0" data-bs-slide-to="0">
                     </div>
                     <div class="item-content align-left">
-                        <h5 class="item-title mbr-fonts-style display-5"><strong><a href="Mallinath Portfolio.html">Mallinath</a>
+                        <h5 class="item-title mbr-fonts-style display-5"><strong><a href="Mallinath-Portfolio.html">Mallinath</a>
 </strong></h5>
                         <h6 class="item-subtitle mbr-fonts-style mb-3 display-7">Yoga Instructor</h6>
                         


### PR DESCRIPTION
I have renamed three files that were using spaces in their filenames, as this was causing mismatches with the sitemap and existing internal links, leading to 'Not Indexed' errors in Google Search Console.

### Changes:
1.  **Renamed Files:**
    *   `Yoga-Classes-In-Bangalore/Corporate Zumba.html` → `Yoga-Classes-In-Bangalore/Corporate-Zumba.html`
    *   `Yoga-Classes-In-Bangalore/Apartment Zumba.html` → `Yoga-Classes-In-Bangalore/Apartment-Zumba.html`
    *   `Mallinath Portfolio.html` → `Mallinath-Portfolio.html`
2.  **Metadata Updates:**
    *   Updated `<link rel="canonical">` and `<meta property="og:url">` in all three renamed files to use the new hyphenated URLs.
3.  **Link Updates:**
    *   Updated the link to Mallinath's portfolio in `index.html` from `Mallinath Portfolio.html` to `Mallinath-Portfolio.html`.
    *   Verified that other pages (like `Corporate.html`) were already correctly linking to the hyphenated versions of the Zumba pages.

These changes ensure that all paths match the filesystem, sitemap, and internal links, allowing search engines to correctly index these pages.

---
*PR created automatically by Jules for task [17864658410352656119](https://jules.google.com/task/17864658410352656119) started by @ZugaFitness*