### PR TITLE
Strategic Pivot: Corporate Yoga Week Campaign Implementation

### DIFF
--- a/Blog/corporate-yoga-day-bangalore.html
+++ b/Blog/corporate-yoga-day-bangalore.html
@@ -3,11 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="International Yoga Day is June 21. Here's everything Bangalore HR teams need to know before booking a corporate yoga session — onsite or online.">
-    <meta name="keywords" content="online yoga class, live yoga online, virtual yoga classes, interactive yoga, Zuga Fitness, Hatha Vinyasa, PCOD yoga, corporate yoga day bangalore">
+    <meta name="description" content="International Yoga Day falls on a Sunday this year. Here's why Bangalore HR teams are booking 'Corporate Yoga Week' (June 16–25) for their office sessions.">
+    <meta name="keywords" content="online yoga class, live yoga online, virtual yoga classes, interactive yoga, Zuga Fitness, Hatha Vinyasa, PCOD yoga, corporate yoga week bangalore">
     <meta name="author" content="Zuga Fitness">
 
-    <title>Planning a Yoga Day Session for Your Bangalore Office? Read This First | Zuga Fitness</title>
+    <title>Planning a Corporate Yoga Week for Your Bangalore Office? | Zuga Fitness</title>
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
@@ -585,8 +585,8 @@
 {
   "@context": "https://schema.org",
   "@type": "BlogPosting",
-  "headline": "Planning a Yoga Day Session for Your Bangalore Office? Read This First",
-  "description": "International Yoga Day is June 21. Here's everything Bangalore HR teams need to know before booking a corporate yoga session — onsite or online.",
+  "headline": "Planning a Corporate Yoga Week for Your Bangalore Office? Read This First",
+  "description": "International Yoga Day falls on a Sunday this year. Here's why Bangalore HR teams are booking 'Corporate Yoga Week' (June 16–25) for their office sessions.",
   "author": {
     "@type": "Organization",
     "name": "Zuga Fitness"
@@ -611,16 +611,16 @@
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://zugafitness.in/Blog/corporate-yoga-day-bangalore.html">
-  <meta property="og:title" content="Planning a Yoga Day Session for Your Bangalore Office? Read This First | Zuga Fitness">
-  <meta property="og:description" content="International Yoga Day is June 21. Here's everything Bangalore HR teams need to know before booking a corporate yoga session — onsite or online.">
+  <meta property="og:title" content="Planning a Corporate Yoga Week for Your Bangalore Office? | Zuga Fitness">
+  <meta property="og:description" content="International Yoga Day falls on a Sunday this year. Here's why Bangalore HR teams are booking 'Corporate Yoga Week' (June 16–25) for their office sessions.">
   <meta property="og:image" content="https://images.unsplash.com/photo-1522071820081-009f0129c71c?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80">
   <meta property="og:site_name" content="Zuga Fitness">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:url" content="https://zugafitness.in/Blog/corporate-yoga-day-bangalore.html">
-  <meta name="twitter:title" content="Planning a Yoga Day Session for Your Bangalore Office? Read This First">
-  <meta name="twitter:description" content="International Yoga Day is June 21. Here's everything Bangalore HR teams need to know before booking a corporate yoga session — onsite or online.">
+  <meta name="twitter:title" content="Planning a Corporate Yoga Week for Your Bangalore Office?">
+  <meta name="twitter:description" content="International Yoga Day falls on a Sunday this year. Here's why Bangalore HR teams are booking 'Corporate Yoga Week' (June 16–25) for their office sessions.">
   <meta name="twitter:image" content="https://images.unsplash.com/photo-1522071820081-009f0129c71c?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80">
 
   <link rel="stylesheet" href="../assets/whatsapp.css">
@@ -655,12 +655,12 @@
     <div class="blog-container">
         <div class="blog-header">
             <div class="blog-meta">
-                <span><i class="far fa-calendar"></i> May 12, 2026</span>
+                <span><i class="far fa-calendar"></i> May 12, 2025</span>
                 <span><i class="far fa-clock"></i> 5 min read</span>
                 <span class="blog-category">Corporate Wellness</span>
             </div>
-            <h1 class="blog-title">Planning a Yoga Day Session for Your Bangalore Office? Read This First</h1>
-            <p class="blog-subtitle">International Yoga Day falls on June 21 every year. And every year, hundreds of Bangalore companies scramble in the last two weeks to find a yoga trainer for their team — only to discover that the good ones are already booked.</p>
+            <h1 class="blog-title">Planning a Corporate Yoga Week for Your Bangalore Office? Read This First</h1>
+            <p class="blog-subtitle">International Yoga Day falls on June 21 every year. But since June 21 falls on a Sunday this year, we've extended our campaign to <strong>Corporate Yoga Week (June 16–25)</strong> so your team can enjoy a premium onsite session during regular weekday work hours.</p>
         </div>
 
         <div class="featured-image">
@@ -685,7 +685,7 @@
                 <p>Most Bangalore companies prefer onsite. There's something about a shared physical experience — colleagues on mats next to each other, laughing through their first Warrior Pose — that a Zoom session can't replicate.</p>
                 <p><strong>Choose onsite if:</strong></p>
                 <ul>
-                    <li>Your team is largely in-office on June 21</li>
+                    <li>Your team is largely in-office during the June 16–25 window</li>
                     <li>You have a usable open space (terrace, lawn, large conference room, cleared floor)</li>
                     <li>Team size is 20–100 people</li>
                 </ul>
@@ -730,16 +730,16 @@
 
             <div class="blog-section">
                 <h2 class="section-title">How to Book</h2>
-                <p>We have 4 onsite slots available across June 21 — morning through evening. Slots are allocated first-come, first-served.</p>
+                <p>We are strictly limiting bookings to <strong>2 onsite slots per day</strong> between June 16 and June 25 to ensure our senior founders personally lead every session. Slots are allocated first-come, first-served.</p>
                 <p>Pricing is simple: ₹5,000 base + ₹100 per head. So a team of 30 costs ₹8,000 total. Early bird bookings made before June 7 receive a ₹1,000 discount. View our <strong><a href="/pricing.html">pricing</a></strong> for more details.</p>
                 <p><strong><a href="https://zugafitness.in/corporate-yoga-day-bangalore.html">Check availability and book your slot →</a></strong></p>
             </div>
 
             <div class="blog-section">
                 <h2 class="section-title">Book Early — Slots Go Fast</h2>
-                <p>Last year, most quality yoga instructors in Bangalore were fully booked for June 21 by the end of May. This year is likely to be the same.</p>
+                <p>Every year, quality corporate yoga instructors in Bangalore are fully booked weeks in advance. With the shift to a weekday model, prime Tuesday and Wednesday slots are disappearing fast.</p>
                 <p>If you're planning a session for your team, the best time to confirm is now — while you have choice of timeslot and can communicate the plan to your employees in advance. We also offer <strong><a href="/Online-Personal-Training-classes.html">Personal Training</a></strong> and specialized programs like <strong><a href="/Online-Yoga-Classes-For-PCOD.html">PCOD Yoga</a></strong> for those looking for individual wellness goals.</p>
-                <p><strong><a href="https://zugafitness.in/corporate-yoga-day-bangalore.html">View available slots for June 21 →</a></strong></p>
+                <p><strong><a href="https://zugafitness.in/corporate-yoga-day-bangalore.html">Check availability for your preferred date →</a></strong></p>
                 <p>Sign up for your <strong><a href="/free-trial.html">Free Trial</a></strong> today!</p>
             </div>
 

--- a/Blog/hire-yoga-trainer-yoga-day-bangalore.html
+++ b/Blog/hire-yoga-trainer-yoga-day-bangalore.html
@@ -660,7 +660,7 @@
                 <span class="blog-category">Corporate Wellness</span>
             </div>
             <h1 class="blog-title">How to Hire a Yoga Trainer for International Yoga Day in Bangalore (2026)</h1>
-            <p class="blog-subtitle">Every year, the same thing happens. An HR manager in Bangalore gets asked to organise something for International Yoga Day on June 21. They leave it until the second week of June. And then they discover that every quality yoga trainer in the city is already booked.</p>
+            <p class="blog-subtitle">Since International Yoga Day (June 21) falls on a Sunday this year, Bangalore HR teams are shifting to <strong>Corporate Yoga Week (June 16–25)</strong>. Here is how to hire the right trainer for your weekday office session.</p>
         </div>
 
         <div class="featured-image">
@@ -684,8 +684,8 @@
             </div>
 
             <div class="blog-section">
-                <h2 class="section-title">Onsite vs Online — What's Right for June 21?</h2>
-                <p>Most Bangalore companies prefer onsite for Yoga Day — the shared physical experience creates a team moment that a screen cannot replicate. If your team is largely in-office on June 21 and you have usable open space, onsite is the better choice.</p>
+                <h2 class="section-title">Onsite vs Online — What's Right for Your Weekday Session?</h2>
+                <p>Most Bangalore companies prefer onsite for Yoga Day — the shared physical experience creates a team moment that a screen cannot replicate. If your team is in-office during June 16–25 and you have usable open space, onsite is the better choice.</p>
                 <p>If your team is hybrid or distributed, a live Zoom session ensures remote employees participate equally. The key word is live — a recorded video played on a projector is not a yoga session, it's a screening. At Zuga Fitness, our <strong><a href="/Online-Yoga-Classes.html">Online Group Classes</a></strong> are always live and interactive.</p>
                 <p>Some companies do both simultaneously: an instructor onsite with the in-office team, while remote employees join the same Zoom feed.</p>
             </div>
@@ -702,7 +702,7 @@
                 <p><strong>4. What do you need from us in terms of space and logistics?</strong><br>
                 A professional instructor gives you a clear answer: dimensions needed per participant, props required (if any), timing recommendations.</p>
                 <p><strong>5. What happens if you cancel on the day?</strong><br>
-                June 21 is a single day. If your trainer cancels at 7am, you need to know there's a backup. Ask what their cancellation policy and contingency plan is.</p>
+                Yoga Day is a high-demand period. If your trainer cancels at 7am, you need to know there's a backup. Ask what their cancellation policy and contingency plan is.</p>
             </div>
 
             <div class="blog-section">
@@ -730,11 +730,11 @@
 
             <div class="blog-section">
                 <h2 class="section-title">Book Early — This Is Not Optional</h2>
-                <p>Quality corporate yoga trainers in Bangalore are fully booked for June 21 by the end of May. Every year without exception. The instructors worth hiring are not sitting idle waiting for last-minute calls.</p>
-                <p>If you're planning a session for your team, confirm your booking this week. Not because we're creating artificial urgency — because the calendar genuinely fills up.</p>
+                <p>Quality corporate yoga trainers in Bangalore are fully booked for Yoga Day weeks in advance. Every year without exception. The instructors worth hiring are not sitting idle waiting for last-minute calls.</p>
+                <p>If you're planning a session for your team, confirm your booking this week. Not because we're creating artificial urgency — because the calendar genuinely fills up fast for weekday slots.</p>
                 <p>We also offer specialized programs such as <strong><a href="/Online-Personal-Training-classes.html">Personal Training</a></strong>, <strong><a href="/Online-Pranayama-Classes.html">Pranayama</a></strong>, and <strong><a href="/Online-Yoga-Classes-For-PCOD.html">PCOD Yoga</a></strong> for those looking for more focused wellness solutions.</p>
-                <p><a href="https://zugafitness.in/corporate-yoga-day-bangalore.html">Check availability for June 21 →</a></p>
-                <p>We have 4 onsite slots across the day — morning through evening, anywhere in Bangalore. Early bird discount applies to bookings before June 7.</p>
+                <p><a href="https://zugafitness.in/corporate-yoga-day-bangalore.html">Check availability for Corporate Yoga Week (June 16–25) →</a></p>
+                <p>We are strictly limiting bookings to 2 onsite slots per day across Bangalore. Early bird discount applies to bookings before June 7.</p>
                 <p>Your team deserves a Yoga Day session that's actually good. Book early enough to make that happen. Start with a <strong><a href="/free-trial.html">Free Trial</a></strong> to see the difference.</p>
             </div>
 
@@ -870,7 +870,7 @@
       "name": "How early should I book a yoga trainer for International Yoga Day?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "For June 21, you should ideally book by the end of May. Quality trainers in Bangalore are usually fully booked 3-4 weeks in advance."
+        "text": "For International Yoga Day sessions, you should ideally book by the end of May. Quality trainers in Bangalore are usually fully booked 3-4 weeks in advance, especially for prime weekday slots."
       }
     },
     {

--- a/Blog/index.html
+++ b/Blog/index.html
@@ -716,8 +716,8 @@
                             <span><i class="far fa-calendar"></i> May 12, 2026</span>
                             <span class="blog-category">Corporate Wellness</span>
                         </div>
-                        <h3 class="blog-title">Planning a Yoga Day Session for Your Bangalore Office? Read This First</h3>
-                        <p class="blog-excerpt">International Yoga Day is June 21. Here's everything Bangalore HR teams need to know before booking a corporate yoga session — onsite or online.</p>
+                        <h2 class="blog-card-title"><a href="corporate-yoga-day-bangalore.html">Planning a Corporate Yoga Week for Your Bangalore Office? Read This First</a></h2>
+                        <p class="blog-excerpt">International Yoga Day falls on a Sunday this year. Here's why Bangalore HR teams are booking 'Corporate Yoga Week' (June 16–25) for their office sessions.</p>
                     </div>
                     <a href="corporate-yoga-day-bangalore.html" class="read-more">Read Full Article</a>
                 </div>

--- a/Blog/yoga-day-activities-office-bangalore.html
+++ b/Blog/yoga-day-activities-office-bangalore.html
@@ -660,12 +660,12 @@
                 <span class="blog-category">Corporate Wellness</span>
             </div>
             <h1 class="blog-title">5 Yoga Day Activities Your Bangalore Office Will Actually Enjoy (2026)</h1>
-            <p class="blog-subtitle">International Yoga Day is June 21. And if you're an HR manager or office admin in Bangalore, you've probably been asked — or are about to be asked — to organise something for the team.</p>
+            <p class="blog-subtitle">International Yoga Day falls on June 21 — which is a Sunday this year. To help HR managers, Zuga Fitness is hosting <strong>Corporate Yoga Week (June 16–25)</strong> so your team can participate during regular office hours.</p>
         </div>
 
         <div class="featured-image">
             <img loading="lazy" src="https://images.unsplash.com/photo-1522071820081-009f0129c71c?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80" alt="Team doing yoga together in a Bangalore office on International Yoga Day">
-            <div class="image-caption">International Yoga Day is June 21 — here's how Bangalore offices are celebrating in 2026</div>
+            <div class="image-caption">International Yoga Day is June 21 — here's how Bangalore offices are celebrating during Corporate Yoga Week</div>
         </div>
 
         <div class="blog-content">
@@ -679,7 +679,7 @@
                 <p>A good corporate yoga session is designed for mixed levels — complete beginners and experienced practitioners can practice side by side, with the instructor offering appropriate modifications for each person in real time.</p>
                 <p><strong>What you need:</strong> Any open space — a terrace, lawn, cleared conference room, or open-plan floor. Each participant needs roughly 2m × 1m of space.</p>
                 <p><strong>What to tell employees:</strong> Wear comfortable clothing. No prior experience needed. Show up with an open mind.</p>
-                <p>Zuga Fitness conducts onsite corporate yoga sessions anywhere in Bangalore. <a href="/corporate-yoga-day-bangalore.html">Only 4 slots available on June 21 →</a></p>
+                <p>Zuga Fitness conducts onsite corporate yoga sessions anywhere in Bangalore. <a href="/corporate-yoga-day-bangalore.html">Strictly 2 slots available per day (June 16–25) →</a></p>
             </div>
 
             <div class="blog-section">
@@ -755,15 +755,15 @@
 
             <div class="blog-section">
                 <h2 class="section-title">Practical Tips for HR Teams</h2>
-                <p><strong>Book early.</strong> Quality corporate yoga instructors in Bangalore are fully booked for June 21 by late May. Every year.</p>
+                <p><strong>Book early.</strong> Quality corporate yoga instructors in Bangalore are fully booked for Yoga Day weeks in advance. With the shift to weekdays, slots are filling up even faster.</p>
                 <p><strong>Communicate in advance.</strong> Tell employees 2 weeks before — what to wear, what time, where. The more informed they are, the higher the participation.</p>
                 <p><strong>Make it optional but encouraged.</strong> Mandatory yoga breeds resentment. Optional yoga with visible leadership participation gets 80% attendance naturally.</p>
                 <p><strong>Capture it.</strong> Photos from a Yoga Day session are excellent internal content — great for LinkedIn, internal newsletters, and next year's culture deck.</p>
             </div>
 
             <div class="blog-section">
-                <h2 class="section-title">Book Your June 21 Slot</h2>
-                <p>Zuga Fitness is conducting onsite corporate yoga sessions across Bangalore on June 21. Certified instructors, all fitness levels, any open space at your premises. Pricing: <strong><a href="/pricing.html">₹5,000 base + ₹100 per head</a></strong>. Early bird discount of ₹1,000 off before June 7.</p>
+                <h2 class="section-title">Book Your Weekday Slot</h2>
+                <p>Zuga Fitness is conducting onsite corporate yoga sessions across Bangalore during Corporate Yoga Week (June 16–25). Certified instructors, all fitness levels, any open space at your premises. Pricing: <strong><a href="/pricing.html">₹5,000 base + ₹100 per head</a></strong>. Early bird discount of ₹1,000 off before June 7.</p>
                 <p><a href="/corporate-yoga-day-bangalore.html">Check availability and book your slot →</a></p>
                 <p>Only 4 onsite slots available. Two are already in discussion. Don't forget to claim your <strong><a href="/free-trial.html">free trial</a></strong> if you are new to Zuga!</p>
             </div>

--- a/corporate-yoga-day-bangalore.html
+++ b/corporate-yoga-day-bangalore.html
@@ -7,8 +7,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
   <link rel="shortcut icon" href="assets/images/photo-2025-03-07-22-31-00.jpg-192x190.jpg" type="image/x-icon">
 
-  <title>Corporate Yoga Day Session Bangalore | Onsite June 21 | Zuga Fitness</title>
-  <meta name="description" content="Book a certified yoga instructor for your Bangalore office this International Yoga Day. Onsite sessions for teams of any size. Only 4 slots on June 21. Early bird discount available.">
+  <title>Corporate Yoga Week Bangalore | June 16–25 | Zuga Fitness</title>
+  <meta name="description" content="Book a premium onsite yoga session for your Bangalore office during Corporate Yoga Week (June 16–25). Skip the Sunday event and book a weekday slot. Strictly 2 slots per day.">
   <link rel="canonical" href="https://zugafitness.in/corporate-yoga-day-bangalore.html" />
 
   <!-- Fonts -->
@@ -173,6 +173,85 @@
       align-items: center;
     }
 
+    /* ── Form Base Styles ── */
+    .form-group { margin-bottom: 1.2rem; display: flex; flex-direction: column; text-align: left; }
+    .form-group label { font-size: 0.85rem; font-weight: 600; margin-bottom: 0.4rem; color: #1A1A1A; }
+    .form-group input,
+    .form-group select,
+    .form-group textarea {
+      padding: 0.75rem 1rem;
+      border: 1.5px solid #E8E0D5;
+      border-radius: 8px;
+      font-size: 0.95rem;
+      font-family: inherit;
+      background: #FFFDF9;
+      color: #1A1A1A;
+      min-height: 48px;
+      transition: border-color 0.2s;
+      width: 100%;
+    }
+    .form-group input:focus,
+    .form-group select:focus,
+    .form-group textarea:focus {
+      outline: none;
+      border-color: var(--teal);
+    }
+    .field-invalid {
+      border-color: var(--orange) !important;
+      background: rgba(232,105,10,0.04) !important;
+    }
+    .field-error {
+      display: none;
+      color: var(--orange);
+      font-size: 0.75rem;
+      margin-top: 0.3rem;
+    }
+    .field-invalid ~ .field-error { display: block; }
+
+    .form-success {
+      background: rgba(11,110,110,0.08);
+      border: 1px solid var(--teal);
+      border-radius: 12px;
+      padding: 2rem;
+      text-align: center;
+      color: var(--teal);
+      font-weight: 600;
+      font-size: 1.05rem;
+      margin-top: 1rem;
+    }
+    .form-error {
+      background: rgba(232,105,10,0.06);
+      border: 1px solid var(--orange);
+      border-radius: 12px;
+      padding: 1.2rem;
+      text-align: center;
+      color: var(--orange);
+      font-size: 0.9rem;
+      margin-top: 1rem;
+    }
+
+    #booking-submit-btn {
+      display: block;
+      width: 100%;
+      padding: 1rem 2rem;
+      margin-top: 1.5rem;
+      background: var(--orange);
+      color: #ffffff;
+      font-size: 1.1rem;
+      font-weight: 700;
+      border: none;
+      border-radius: 50px;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+    #booking-submit-btn:hover {
+      background: #bf5608;
+    }
+    #booking-submit-btn:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+
     /* Final CTA */
     .final-cta {
       background-color: var(--orange);
@@ -192,8 +271,8 @@
   {
     "@context": "https://schema.org/",
     "@type": "Service",
-    "name": "Corporate Yoga Day Session",
-    "description": "Onsite corporate yoga sessions in Bangalore for International Yoga Day.",
+    "name": "Corporate Yoga Week Sessions",
+    "description": "Onsite corporate yoga and breathwork sessions in Bangalore for Corporate Yoga Week (June 16–25).",
     "provider": {
       "@type": "LocalBusiness",
       "name": "Zuga Fitness",
@@ -282,10 +361,10 @@
   <div class="container">
     <div class="row align-items-center">
       <div class="col-md-6">
-        <h1 class="display-3 mb-4">Bring Yoga to Your Office This June 21</h1>
-        <p class="lead mb-5" style="font-size: 1.25rem;">We send certified yoga instructors directly to your Bangalore workplace — for International Yoga Day team sessions your employees will actually enjoy.</p>
+        <h1 class="display-3 mb-4">Celebrate International Yoga Day on Your Terms</h1>
+        <p class="lead mb-5" style="font-size: 1.25rem;">Don't ask employees to log in on a weekend. Book a premium, 60-minute onsite yoga and breathwork session directly on your office floor during work hours, anytime between <strong>June 16 and June 25</strong>.</p>
         <div class="mbr-section-btn">
-          <a class="btn btn-orange display-4" href="/index.html#form02-6">Check Slot Availability</a>
+          <a class="btn btn-orange display-4" href="#booking-form">Book Your Weekday Slot</a>
         </div>
       </div>
       <div class="col-md-6 text-center">
@@ -315,7 +394,7 @@
         <div class="trust-stat">All Fitness Levels Welcome</div>
       </div>
       <div class="col-6 col-md-3">
-        <div class="trust-stat">Only 4 Slots on June 21</div>
+        <div class="trust-stat">Strictly 2 Slots Per Day</div>
       </div>
     </div>
   </div>
@@ -369,6 +448,7 @@
           <li><span style="color: var(--orange); font-weight: bold; margin-right: 10px;">3.</span> Suitable for all fitness levels — no experience needed</li>
           <li><span style="color: var(--orange); font-weight: bold; margin-right: 10px;">4.</span> Includes breathwork and a guided cooldown</li>
           <li><span style="color: var(--orange); font-weight: bold; margin-right: 10px;">5.</span> Session can be customised for your team size and space</li>
+          <li><span style="color: var(--orange); font-weight: bold; margin-right: 10px;">6.</span> <strong>Hybrid-friendly:</strong> If your team is partially remote, we can live-stream your onsite session simultaneously via Zoom/Teams.</li>
         </ul>
       </div>
       <div class="col-md-6 text-center">
@@ -435,9 +515,9 @@
     <div class="text-center mt-4">
         <p class="display-4" style="font-size: 0.9rem; color: #777;">Prefer online? Zoom sessions available at ₹5,000 flat for up to 50 people.</p>
         <div class="mbr-section-btn mt-4">
-          <a class="btn btn-orange display-4" href="/index.html#form02-6">Book Your Slot Now</a>
+          <a class="btn btn-orange display-4" href="#booking-form">Book Your Weekday Slot Now</a>
         </div>
-        <p class="mt-3 text-muted" style="font-size: 0.9rem;">Only 4 onsite slots available on June 21</p>
+        <p class="mt-3 text-muted" style="font-size: 0.9rem;">Strictly 2 corporate onsite slots per day</p>
     </div>
   </div>
 </section>
@@ -484,7 +564,106 @@
   </div>
 </section>
 
-<!-- Section 8: FAQ -->
+<!-- Section 8: Booking Form -->
+<section class="zuga-section" id="booking-form">
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-lg-8">
+        <div class="pricing-card" style="padding: 50px; border-top: 5px solid var(--orange);">
+          <h2 class="display-4 mb-4">Book Your Weekday Slot</h2>
+          <p class="mb-5">Fill out the form below and our team will get back to you within 24 hours to confirm your Corporate Yoga Week session.</p>
+
+          <form id="yoga-day-booking-form" action="https://formspree.io/f/mnjlyoqr" method="POST" novalidate>
+            <input type="text" name="_gotcha" style="display:none" tabindex="-1" autocomplete="off" />
+            <input type="hidden" name="_subject" value="🧘 NEW: Corporate Yoga Week Booking Request" />
+            <input type="hidden" name="_next" value="https://zugafitness.in/thank-you.html" />
+
+            <div class="row">
+              <div class="col-md-6">
+                <div class="form-group">
+                  <label for="name">Your Name *</label>
+                  <input type="text" id="name" name="name" placeholder="Full Name" required />
+                  <span class="field-error">Please enter your name</span>
+                </div>
+              </div>
+              <div class="col-md-6">
+                <div class="form-group">
+                  <label for="company">Company Name *</label>
+                  <input type="text" id="company" name="company" placeholder="Organization Name" required />
+                  <span class="field-error">Please enter company name</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="row">
+              <div class="col-md-6">
+                <div class="form-group">
+                  <label for="email">Work Email *</label>
+                  <input type="email" id="email" name="email" placeholder="email@company.com" required />
+                  <span class="field-error">Please enter a valid email</span>
+                </div>
+              </div>
+              <div class="col-md-6">
+                <div class="form-group">
+                  <label for="phone">Phone / WhatsApp *</label>
+                  <input type="tel" id="phone" name="phone" placeholder="Mobile Number" required />
+                  <span class="field-error">Please enter phone number</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="form-group">
+              <label for="preferred-date">Preferred Celebration Date *</label>
+              <select id="preferred-date" name="preferred_date" required>
+                <option value="" disabled selected>Select a Weekday (June 16–25)</option>
+                <option value="June 16 (Tuesday)">June 16 (Tuesday)</option>
+                <option value="June 17 (Wednesday)">June 17 (Wednesday)</option>
+                <option value="June 18 (Thursday)">June 18 (Thursday)</option>
+                <option value="June 19 (Friday)">June 19 (Friday)</option>
+                <option value="June 22 (Monday)">June 22 (Monday)</option>
+                <option value="June 23 (Tuesday)">June 23 (Tuesday)</option>
+                <option value="June 24 (Wednesday)">June 24 (Wednesday)</option>
+                <option value="June 25 (Thursday)">June 25 (Thursday)</option>
+                <option value="Weekend / Special Request">Weekend / Special Request (June 20-21)</option>
+              </select>
+              <span class="field-error">Please select a preferred date</span>
+            </div>
+
+            <div class="form-group">
+              <label for="team-size">Estimated Team Size</label>
+              <select id="team-size" name="team_size">
+                <option value="Under 20">Under 20 people</option>
+                <option value="20-50">20-50 people</option>
+                <option value="50-100">50-100 people</option>
+                <option value="100+">100+ people</option>
+              </select>
+            </div>
+
+            <div class="form-group">
+              <label for="message">Specific Requirements or Questions</label>
+              <textarea id="message" name="message" rows="3" placeholder="Tell us about your space or any specific needs..."></textarea>
+            </div>
+
+            <button type="submit" id="booking-submit-btn">
+              <span class="btn-text">Check Availability for My Date</span>
+              <span class="btn-loading" style="display:none">Sending... ⏳</span>
+            </button>
+
+            <div class="form-success" style="display:none">
+              ✅ Booking request sent! We'll call you shortly to confirm your slot.
+            </div>
+            <div class="form-error" style="display:none">
+              ❌ Something went wrong. Please email us at <a href="mailto:zugafitness24@gmail.com">zugafitness24@gmail.com</a>
+            </div>
+          </form>
+          <p class="text-muted mt-3" style="font-size: 0.8rem;">Note: Early bird discount (₹1,000 OFF) applies for all bookings confirmed before June 7th.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Section 9: FAQ -->
 <section class="zuga-section">
   <div class="container">
     <h2 class="display-4 text-center mb-5">Common Questions</h2>
@@ -514,6 +693,12 @@
             <p>Yes. Share your team size, any specific health considerations, and your goals — we'll tailor the session accordingly.</p>
           </div>
         </div>
+        <div class="faq-item">
+          <div class="faq-question" data-bs-toggle="collapse" data-bs-target="#faq5">Why is it "Corporate Yoga Week"? <span>+</span></div>
+          <div id="faq5" class="collapse mt-3">
+            <p>Since International Yoga Day (June 21) falls on a Sunday this year, we've extended our onsite availability from June 16 to June 25. This allows your team to participate during regular work hours on a weekday that suits your schedule best.</p>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -522,10 +707,10 @@
 <!-- Section 9: Final CTA -->
 <section class="final-cta">
   <div class="container">
-    <h2 class="display-3 mb-4 text-white">Only 4 onsite slots available on June 21.</h2>
-    <p class="lead mb-5 text-white">Bangalore companies are booking fast — don't miss out.</p>
+    <h2 class="display-3 mb-4 text-white">Strictly 2 corporate onsite slots per day.</h2>
+    <p class="lead mb-5 text-white">Bangalore companies are booking fast for Corporate Yoga Week (June 16–25) — don't miss out.</p>
     <div class="mbr-section-btn">
-      <a class="btn btn-white-outline display-4" href="/index.html#form02-6">Check Availability Now</a>
+      <a class="btn btn-white-outline display-4" href="#booking-form">Check Availability Now</a>
     </div>
   </div>
 </section>
@@ -596,6 +781,71 @@
 <script src="/assets/dropdown/js/navbar-dropdown.js"></script>
 <script src="/assets/theme/js/script.js"></script>
 
+<script>
+(function() {
+  const form = document.getElementById('yoga-day-booking-form');
+  if (!form) return;
+
+  form.addEventListener('submit', async function(e) {
+    e.preventDefault();
+
+    // Validate
+    let valid = true;
+    form.querySelectorAll('[required]').forEach(function(field) {
+      if (!field.value.trim()) {
+        field.classList.add('field-invalid');
+        valid = false;
+      } else {
+        field.classList.remove('field-invalid');
+      }
+    });
+    if (!valid) return;
+
+    // Loading state
+    const btn = form.querySelector('button[type="submit"]');
+    const btnText = btn.querySelector('.btn-text');
+    const btnLoading = btn.querySelector('.btn-loading');
+    const successBox = form.querySelector('.form-success');
+    const errorBox = form.querySelector('.form-error');
+
+    btnText.style.display = 'none';
+    btnLoading.style.display = 'inline';
+    btn.disabled = true;
+
+    try {
+      const response = await fetch(form.action, {
+        method: 'POST',
+        body: new FormData(form),
+        headers: { 'Accept': 'application/json' }
+      });
+
+      if (response.ok) {
+        form.querySelectorAll('.form-group, button, .row, h2, p').forEach(el => {
+            if(!el.classList.contains('form-success')) el.style.display = 'none';
+        });
+        if (successBox) successBox.style.display = 'block';
+        setTimeout(function() {
+          window.location.href = '/thank-you.html';
+        }, 3000);
+      } else {
+        throw new Error('Form submission failed');
+      }
+    } catch(err) {
+      if (errorBox) errorBox.style.display = 'block';
+      btnText.style.display = 'inline';
+      btnLoading.style.display = 'none';
+      btn.disabled = false;
+    }
+  });
+
+  // Clear error highlight on input
+  form.querySelectorAll('input, select, textarea').forEach(function(el) {
+    el.addEventListener('input', function() {
+      el.classList.remove('field-invalid');
+    });
+  });
+})();
+</script>
 
 <a href="https://wa.me/917676379909?text=Hi%20Zuga!%20I%27d%20like%20to%20know%20more%20about%20your%20classes"
    class="whatsapp-float"

--- a/index.html
+++ b/index.html
@@ -503,12 +503,12 @@
             <!-- Card 2: Corporate Yoga Day -->
             <div class="col-12 col-md-6 col-lg-4 mb-4">
                 <div class="service-card" style="background: white; border-radius: 12px; box-shadow: 0 4px 20px rgba(0,0,0,0.07); overflow: hidden; border-top: 5px solid #E8690A; transition: all 0.3s ease; height: 100%; display: flex; flex-direction: column;">
-                    <img loading="lazy" src="assets/images/corporate1.jpg" alt="Corporate Yoga Day" style="width: 100%; height: 220px; object-fit: cover;">
+                    <img loading="lazy" src="assets/images/corporate1.jpg" alt="Corporate Yoga Week" style="width: 100%; height: 220px; object-fit: cover;">
                     <div class="card-body" style="padding: 1.5rem; flex-grow: 1; display: flex; flex-direction: column;">
-                        <span style="background: #E8690A; color: white; padding: 4px 12px; border-radius: 20px; font-size: 0.7rem; font-weight: 600; display: inline-block; margin-bottom: 8px;">Only 4 Slots Left</span>
-                        <h3 class="mbr-fonts-style" style="font-size: 1.2rem; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 0.5rem;"><a href="/corporate-yoga-day-bangalore.html">Corporate Yoga Day</a></h3>
+                        <span style="background: #E8690A; color: white; padding: 4px 12px; border-radius: 20px; font-size: 0.7rem; font-weight: 600; display: inline-block; margin-bottom: 8px;">2 Slots/Day Left</span>
+                        <h3 class="mbr-fonts-style" style="font-size: 1.2rem; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 0.5rem;"><a href="/corporate-yoga-day-bangalore.html">Corporate Yoga Week</a></h3>
                         <p class="mbr-fonts-style" style="font-size: 0.8rem; color: #E8690A; font-weight: 600; text-transform: uppercase; margin-bottom: 0.5rem;">In-Person Bangalore</p>
-                        <p class="mbr-fonts-style" style="font-size: 0.9rem; color: #555; margin-bottom: 1rem;">We bring certified yoga instructors to your Bangalore office. Perfect for International Yoga Day — June 21. Limited slots.</p>
+                        <p class="mbr-fonts-style" style="font-size: 0.9rem; color: #555; margin-bottom: 1rem;">We bring certified yoga instructors to your Bangalore office. Perfect for Corporate Yoga Week — June 16-25. Strictly limited slots.</p>
                         <div style="margin-top: auto;">
                             <a href="/corporate-yoga-day-bangalore.html" style="color: #E8690A; text-decoration: none; font-weight: 600;">Check Availability →</a>
                         </div>


### PR DESCRIPTION
This update executes a major strategic shift for the International Yoga Day campaign. Since June 21 falls on a Sunday, we have pivoted to a 10-day "Corporate Yoga Week" (June 16–25) to better accommodate weekday corporate bookings in Bangalore. 

Key changes include a complete copy overhaul of the landing page, the introduction of a high-conversion booking form with date-specific selection logic, and a site-wide synchronization effort covering the homepage and the blog ecosystem. The scarcity model has been updated from a total-slot limit to a daily-capacity limit to drive urgency for specific weekdays.

---
*PR created automatically by Jules for task [13752037119316866080](https://jules.google.com/task/13752037119316866080) started by @ZugaFitness*