### PR TITLE
Update International Yoga Day capacity to 4 slots

### DIFF
--- a/Blog/yoga-day-activities-office-bangalore.html
+++ b/Blog/yoga-day-activities-office-bangalore.html
@@ -679,7 +679,7 @@
                 <p>A good corporate yoga session is designed for mixed levels — complete beginners and experienced practitioners can practice side by side, with the instructor offering appropriate modifications for each person in real time.</p>
                 <p><strong>What you need:</strong> Any open space — a terrace, lawn, cleared conference room, or open-plan floor. Each participant needs roughly 2m × 1m of space.</p>
                 <p><strong>What to tell employees:</strong> Wear comfortable clothing. No prior experience needed. Show up with an open mind.</p>
-                <p>Zuga Fitness conducts onsite corporate yoga sessions anywhere in Bangalore. <a href="/corporate-yoga-day-bangalore.html">Strictly 2 slots available per day (June 16–25) →</a></p>
+                <p>Zuga Fitness conducts onsite corporate yoga sessions anywhere in Bangalore. <a href="/corporate-yoga-day-bangalore.html">Strictly 4 slots available per day (June 16–25) →</a></p>
             </div>
 
             <div class="blog-section">

--- a/corporate-yoga-day-bangalore.html
+++ b/corporate-yoga-day-bangalore.html
@@ -8,7 +8,7 @@
   <link rel="shortcut icon" href="assets/images/photo-2025-03-07-22-31-00.jpg-192x190.jpg" type="image/x-icon">
 
   <title>Corporate Yoga Week Bangalore | June 16–25 | Zuga Fitness</title>
-  <meta name="description" content="Book a premium onsite yoga session for your Bangalore office during Corporate Yoga Week (June 16–25). Skip the Sunday event and book a weekday slot. Strictly 2 slots per day.">
+  <meta name="description" content="Book a premium onsite yoga session for your Bangalore office during Corporate Yoga Week (June 16–25). Skip the Sunday event and book a weekday slot. Strictly 4 slots per day.">
   <link rel="canonical" href="https://zugafitness.in/corporate-yoga-day-bangalore.html" />
 
   <!-- Fonts -->
@@ -394,7 +394,7 @@
         <div class="trust-stat">All Fitness Levels Welcome</div>
       </div>
       <div class="col-6 col-md-3">
-        <div class="trust-stat">Strictly 2 Slots Per Day</div>
+        <div class="trust-stat">Strictly 4 Slots Per Day</div>
       </div>
     </div>
   </div>
@@ -517,7 +517,7 @@
         <div class="mbr-section-btn mt-4">
           <a class="btn btn-orange display-4" href="#booking-form">Book Your Weekday Slot Now</a>
         </div>
-        <p class="mt-3 text-muted" style="font-size: 0.9rem;">Strictly 2 corporate onsite slots per day</p>
+        <p class="mt-3 text-muted" style="font-size: 0.9rem;">Strictly 4 corporate onsite slots per day</p>
     </div>
   </div>
 </section>
@@ -707,7 +707,7 @@
 <!-- Section 9: Final CTA -->
 <section class="final-cta">
   <div class="container">
-    <h2 class="display-3 mb-4 text-white">Strictly 2 corporate onsite slots per day.</h2>
+    <h2 class="display-3 mb-4 text-white">We host strictly 4 onsite office slots per day across Bangalore to ensure our premium senior instructors can manage the energy of each floor. Slots for peak corporate hours (11 AM and 4 PM) are filling up fast.</h2>
     <p class="lead mb-5 text-white">Bangalore companies are booking fast for Corporate Yoga Week (June 16–25) — don't miss out.</p>
     <div class="mbr-section-btn">
       <a class="btn btn-white-outline display-4" href="#booking-form">Check Availability Now</a>

--- a/index.html
+++ b/index.html
@@ -505,7 +505,7 @@
                 <div class="service-card" style="background: white; border-radius: 12px; box-shadow: 0 4px 20px rgba(0,0,0,0.07); overflow: hidden; border-top: 5px solid #E8690A; transition: all 0.3s ease; height: 100%; display: flex; flex-direction: column;">
                     <img loading="lazy" src="assets/images/corporate1.jpg" alt="Corporate Yoga Week" style="width: 100%; height: 220px; object-fit: cover;">
                     <div class="card-body" style="padding: 1.5rem; flex-grow: 1; display: flex; flex-direction: column;">
-                        <span style="background: #E8690A; color: white; padding: 4px 12px; border-radius: 20px; font-size: 0.7rem; font-weight: 600; display: inline-block; margin-bottom: 8px;">2 Slots/Day Left</span>
+                        <span style="background: #E8690A; color: white; padding: 4px 12px; border-radius: 20px; font-size: 0.7rem; font-weight: 600; display: inline-block; margin-bottom: 8px;">4 Slots/Day Left</span>
                         <h3 class="mbr-fonts-style" style="font-size: 1.2rem; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 0.5rem;"><a href="/corporate-yoga-day-bangalore.html">Corporate Yoga Week</a></h3>
                         <p class="mbr-fonts-style" style="font-size: 0.8rem; color: #E8690A; font-weight: 600; text-transform: uppercase; margin-bottom: 0.5rem;">In-Person Bangalore</p>
                         <p class="mbr-fonts-style" style="font-size: 0.9rem; color: #555; margin-bottom: 1rem;">We bring certified yoga instructors to your Bangalore office. Perfect for Corporate Yoga Week — June 16-25. Strictly limited slots.</p>


### PR DESCRIPTION
This PR updates the International Yoga Day / Corporate Yoga Week campaign capacity details from 2 slots to 4 slots across the landing page and related site sections. 

Key changes:
1. **Landing Page (`corporate-yoga-day-bangalore.html`):** Updated capacity count in Meta Description, Trust Bar, Pricing Footer, and Final CTA. Added specific premium phrasing to the CTA regarding senior instructors and peak hour availability.
2. **Homepage (`index.html`):** Updated the scarcity badge in the Corporate Yoga Day feature card.
3. **Blog (`Blog/yoga-day-activities-office-bangalore.html`):** Updated the promotional anchor text to reflect the 4-slot capacity.

All styling, brand colors, and layouts have been preserved. Verification was performed using Playwright screenshots and textual analysis.

---
*PR created automatically by Jules for task [8654425186005488660](https://jules.google.com/task/8654425186005488660) started by @ZugaFitness*