### PR TITLE
Fix Canonicals and HTTPS Redirects

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,2 +1,10 @@
+RewriteEngine On
+
+RewriteCond %{HTTPS} off
+RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+
+RewriteCond %{HTTP_HOST} ^www\.zugafitness\.in [NC]
+RewriteRule ^(.*)$ https://zugafitness.in/$1 [L,R=301]
+
 Redirect 301 "/Mallinath Portfolio.html" /Mallinath-Portfolio.html
 Redirect 301 "/Anusha Portfolio.html" /Anusha-Portfolio.html

--- a/Yoga-Classes-In-Bangalore/index.html
+++ b/Yoga-Classes-In-Bangalore/index.html
@@ -1221,7 +1221,7 @@
             }
         }
     </style>
-  <link rel="canonical" href="https://zugafitness.in/Yoga-Classes-In-Bangalore/" />
+  <link rel="canonical" href="https://zugafitness.in/Yoga-Classes-In-Bangalore/index.html" />
   <meta property="og:title" content="Zuga Fitness | Corporate & Apartment Wellness in Bangalore">
   <meta property="og:description" content="Premium corporate wellness programs and apartment community wellness services in Bangalore. Enhance workplace productivity and residential wellbeing with Zuga Fitness.">
   <meta property="og:image" content="https://zugafitness.in/assets/images/photo-2025-03-07-22-31-00.jpg-192x190.jpg">

--- a/index.html
+++ b/index.html
@@ -211,7 +211,7 @@
     }
   </style>
   <meta name="description" content="Join live online yoga classes with real-time instructor feedback. Max 10 students. 3 timezones (EST/GMT/GST). Free trial - no credit card required. 4.9★ rating.">
-  <link rel="canonical" href="https://zugafitness.in/">
+  <link rel="canonical" href="https://zugafitness.in/" />
 
   <!-- Hreflang Tags for Global global community Audience -->
   <link rel="alternate" hreflang="en-us" href="https://zugafitness.in/">


### PR DESCRIPTION
This PR completes three SEO and configuration fixes:
1. Updates the canonical tag in the root index.html to https://zugafitness.in/ with a trailing slash and self-closing format.
2. Updates the canonical tag in /Yoga-Classes-In-Bangalore/index.html to point explicitly to the file path https://zugafitness.in/Yoga-Classes-In-Bangalore/index.html.
3. Adds RewriteEngine rules to the top of .htaccess to enforce HTTPS and redirect www to the non-www root domain.

---
*PR created automatically by Jules for task [11457161774801817131](https://jules.google.com/task/11457161774801817131) started by @ZugaFitness*