### PR TITLE
Restore Blog Posts and Update Sitemap

### DIFF
--- a/Blog/how-long-yoga-takes-to-transform-your-body.html
+++ b/Blog/how-long-yoga-takes-to-transform-your-body.html
@@ -1,0 +1,637 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Wondering how long yoga takes to show results? Expert timeline and what to expect in the first 30, 60 and 90 days of yoga practice at Zuga Fitness.">
+    <meta name="keywords" content="yoga transformation, yoga results timeline, 30 days of yoga, 90 days of yoga, Zuga Fitness">
+    <meta name="author" content="Zuga Fitness">
+
+    <title>How Long Does Yoga Take to Transform Your Body? | Zuga Fitness</title>
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
+
+    <style>
+        :root {
+            --primary: #4a7c59;
+            --secondary: #8d9f87;
+            --accent: #d0b49f;
+            --light: #f4f1e9;
+            --dark: #2d3319;
+            --text: #333;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Poppins', sans-serif;
+            background-color: var(--light);
+            color: var(--text);
+            line-height: 1.7;
+        }
+
+        /* Header Styles */
+        header {
+            background-color: white;
+            box-shadow: 0 2px 15px rgba(0,0,0,0.1);
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            padding: 0 5%;
+        }
+
+        .navbar {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 1.2rem 0;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .logo-container {
+            display: flex;
+            align-items: center;
+            gap: 15px;
+        }
+
+        .logo {
+            height: 60px;
+            width: 60px;
+            border-radius: 50%;
+            background-color: var(--primary);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: white;
+            font-weight: 700;
+            font-size: 1.8rem;
+        }
+
+        .logo-text {
+            font-family: 'Playfair Display', serif;
+            font-size: 1.8rem;
+            font-weight: 700;
+            color: var(--primary);
+            letter-spacing: 1px;
+        }
+
+        .nav-links {
+            display: flex;
+            gap: 30px;
+        }
+
+        .nav-links a {
+            text-decoration: none;
+            color: var(--dark);
+            font-weight: 500;
+            font-size: 1.1rem;
+            transition: color 0.3s;
+            position: relative;
+        }
+
+        .nav-links a:hover {
+            color: var(--primary);
+        }
+
+        .nav-links a.active {
+            color: var(--primary);
+            font-weight: 600;
+        }
+
+        .nav-links a.active::after {
+            content: '';
+            position: absolute;
+            bottom: -5px;
+            left: 0;
+            width: 100%;
+            height: 3px;
+            background-color: var(--primary);
+            border-radius: 2px;
+        }
+
+        .cta-button {
+            background-color: var(--primary);
+            color: white;
+            border: none;
+            padding: 10px 25px;
+            border-radius: 30px;
+            font-size: 1rem;
+            font-weight: 500;
+            cursor: pointer;
+            transition: all 0.3s;
+            text-decoration: none;
+            display: inline-block;
+        }
+
+        .cta-button:hover {
+            background-color: #3a6547;
+            transform: translateY(-2px);
+            box-shadow: 0 4px 10px rgba(74, 124, 89, 0.3);
+        }
+
+        /* Breadcrumb */
+        .breadcrumb {
+            max-width: 1200px;
+            margin: 20px auto;
+            padding: 0 20px;
+            font-size: 0.9rem;
+        }
+
+        .breadcrumb a {
+            color: var(--primary);
+            text-decoration: none;
+        }
+
+        .breadcrumb a:hover {
+            text-decoration: underline;
+        }
+
+        /* Blog Content */
+        .blog-container {
+            max-width: 900px;
+            margin: 40px auto;
+            padding: 0 20px;
+        }
+
+        .blog-header {
+            text-align: center;
+            margin-bottom: 40px;
+        }
+
+        .blog-meta {
+            display: flex;
+            justify-content: center;
+            gap: 20px;
+            margin-bottom: 15px;
+            font-size: 0.95rem;
+            color: var(--secondary);
+        }
+
+        .blog-category {
+            background: var(--accent);
+            color: white;
+            padding: 3px 12px;
+            border-radius: 20px;
+            font-size: 0.85rem;
+            font-weight: 500;
+        }
+
+        .blog-title {
+            font-family: 'Playfair Display', serif;
+            font-size: 2.8rem;
+            margin-bottom: 20px;
+            color: var(--dark);
+            line-height: 1.2;
+        }
+
+        .blog-subtitle {
+            font-size: 1.3rem;
+            color: #555;
+            max-width: 700px;
+            margin: 0 auto 30px;
+            font-weight: 400;
+        }
+
+        .featured-image {
+            width: 100%;
+            height: 500px;
+            border-radius: 12px;
+            overflow: hidden;
+            margin-bottom: 40px;
+            position: relative;
+        }
+
+        .featured-image img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+        }
+
+        .blog-content {
+            background: white;
+            padding: 40px;
+            border-radius: 15px;
+            box-shadow: 0 5px 20px rgba(0,0,0,0.05);
+        }
+
+        .content-intro {
+            font-size: 1.1rem;
+            margin-bottom: 40px;
+            padding-bottom: 20px;
+            border-bottom: 1px solid #eee;
+        }
+
+        .blog-section {
+            margin-bottom: 40px;
+        }
+
+        .section-title {
+            font-family: 'Playfair Display', serif;
+            font-size: 1.8rem;
+            margin-bottom: 20px;
+            color: var(--primary);
+            position: relative;
+            padding-bottom: 10px;
+        }
+
+        .section-title::after {
+            content: '';
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            width: 60px;
+            height: 3px;
+            background-color: var(--accent);
+        }
+
+        .tip-box {
+            background: rgba(212, 237, 218, 0.3);
+            border-left: 4px solid var(--primary);
+            padding: 20px;
+            margin: 30px 0;
+            border-radius: 0 8px 8px 0;
+        }
+
+        .author-section {
+            display: flex;
+            gap: 20px;
+            align-items: center;
+            margin: 50px 0 30px;
+            padding: 20px;
+            background: rgba(208, 180, 159, 0.1);
+            border-radius: 12px;
+        }
+
+        .author-image {
+            width: 100px;
+            height: 100px;
+            border-radius: 50%;
+            overflow: hidden;
+        }
+
+        .author-image img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+        }
+
+        .author-info h3 {
+            font-size: 1.3rem;
+            margin-bottom: 5px;
+        }
+
+        .author-info p {
+            color: #666;
+            font-size: 0.95rem;
+        }
+
+        /* Newsletter */
+        .newsletter {
+            background: linear-gradient(to right, var(--primary), var(--secondary));
+            padding: 70px 0;
+            text-align: center;
+            color: white;
+            margin: 80px 0;
+        }
+
+        .newsletter h3 {
+            font-family: 'Playfair Display', serif;
+            font-size: 2.2rem;
+            margin-bottom: 20px;
+        }
+
+        .newsletter p {
+            max-width: 600px;
+            margin: 0 auto 30px;
+            font-size: 1.1rem;
+        }
+
+        .subscribe-form {
+            display: flex;
+            max-width: 500px;
+            margin: 0 auto;
+        }
+
+        .subscribe-form input {
+            flex: 1;
+            padding: 15px 20px;
+            border: none;
+            border-radius: 30px 0 0 30px;
+            font-size: 1rem;
+            outline: none;
+        }
+
+        .subscribe-form button {
+            background: var(--accent);
+            color: white;
+            border: none;
+            padding: 0 30px;
+            border-radius: 0 30px 30px 0;
+            font-weight: 500;
+            cursor: pointer;
+            transition: background 0.3s;
+        }
+
+        .subscribe-form button:hover {
+            background: #c0a088;
+        }
+
+        /* Footer */
+        footer {
+            background: var(--dark);
+            color: white;
+            padding: 60px 0 30px;
+        }
+
+        .footer-content {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 20px;
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 40px;
+        }
+
+        .footer-column h3 {
+            font-size: 1.3rem;
+            margin-bottom: 25px;
+            position: relative;
+            padding-bottom: 10px;
+        }
+
+        .footer-column h3::after {
+            content: '';
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            width: 50px;
+            height: 2px;
+            background: var(--accent);
+        }
+
+        .footer-links {
+            list-style: none;
+        }
+
+        .footer-links li {
+            margin-bottom: 12px;
+        }
+
+        .footer-links a {
+            color: #ccc;
+            text-decoration: none;
+            transition: color 0.3s;
+        }
+
+        .footer-links a:hover {
+            color: white;
+        }
+
+        .social-links {
+            display: flex;
+            gap: 15px;
+            margin-top: 20px;
+        }
+
+        .social-links a {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 40px;
+            height: 40px;
+            background: rgba(255,255,255,0.1);
+            border-radius: 50%;
+            color: white;
+            text-decoration: none;
+            transition: all 0.3s;
+        }
+
+        .social-links a:hover {
+            background: var(--accent);
+            transform: translateY(-3px);
+        }
+
+        .copyright {
+            text-align: center;
+            padding-top: 40px;
+            margin-top: 40px;
+            border-top: 1px solid rgba(255,255,255,0.1);
+            color: #aaa;
+            font-size: 0.9rem;
+        }
+
+        /* Responsive Design */
+        @media (max-width: 768px) {
+            .navbar {
+                flex-direction: column;
+                gap: 20px;
+                padding: 20px 0;
+            }
+
+            .nav-links {
+                gap: 15px;
+                flex-wrap: wrap;
+                justify-content: center;
+            }
+
+            .blog-title {
+                font-size: 2.3rem;
+            }
+
+            .featured-image {
+                height: 300px;
+            }
+
+            .blog-content {
+                padding: 30px 20px;
+            }
+
+            .author-section {
+                flex-direction: column;
+                text-align: center;
+            }
+        }
+    </style>
+  <link rel="canonical" href="https://zugafitness.in/Blog/how-long-yoga-takes-to-transform-your-body.html" />
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How long does it take to see results from yoga?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Most people notice initial changes like better flexibility, improved sleep and reduced stress within the first 2 to 4 weeks of regular yoga practice. More visible physical changes like improved muscle tone and posture typically appear after 6 to 8 weeks of consistent practice."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How many times a week should I do yoga to see results?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Practising yoga at least 3 to 4 times per week is recommended to see consistent results. Daily practice of even 20 minutes will produce faster transformation than occasional longer sessions."
+      }
+    }
+  ]
+}
+</script>
+
+</head>
+<body>
+    <!-- Header -->
+    <header>
+        <div class="navbar">
+            <div class="logo-container">
+                <div class="logo">Z</div>
+                <div class="logo-text">Zuga Fitness</div>
+            </div>
+
+             <div class="nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../Online-Yoga-Classes.html">Classes</a>
+                <a href="../pricing.html">Pricing</a>
+                <a href="../Blog/index.html">Blog</a>
+                <a href="../index.html#form02-6">Contact</a>
+            </div>
+
+            <a href="../free-trial.html" class="cta-button">Try Free Class</a>
+        </div>
+    </header>
+
+    <!-- Breadcrumb -->
+    <div class="breadcrumb">
+        <a href="../index.html">Home</a> / <a href="index.html">Blog</a> / How Long Yoga Takes to Transform Your Body
+    </div>
+
+    <!-- Blog Content -->
+    <div class="blog-container">
+        <div class="blog-header">
+            <div class="blog-meta">
+                <span><i class="far fa-calendar"></i> May 15, 2026</span>
+                <span class="blog-category">Fitness Timeline</span>
+            </div>
+            <h1 class="blog-title">How Long Does Yoga Take to Transform Your Body?</h1>
+        </div>
+
+        <div class="featured-image">
+            <img loading="lazy" src="https://images.unsplash.com/photo-1544367567-0f2fcb009e0b?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80" alt="Transformation through yoga">
+        </div>
+
+        <div class="blog-content">
+            <div class="content-intro">
+                <p>Starting a new fitness journey often comes with the question: "When will I see results?" Yoga is a powerful practice that offers a unique timeline of transformation, affecting not just your muscles, but your mind and overall wellbeing. At Zuga Fitness, we guide practitioners through every stage of this journey.</p>
+            </div>
+
+            <div class="blog-section">
+                <h2 class="section-title">What to Expect in the First 30 Days</h2>
+                <p>During the initial month of regular practice, the most immediate changes are internal. Many students report a significant improvement in their sleep quality and a noticeable reduction in daily stress levels. As your nervous system begins to adapt to mindful breathing and movement, you'll start to feel more centered and calm throughout the day.</p>
+                <p>Physically, you'll begin to notice initial improvements in your flexibility. Tight hamstrings and shoulders start to loosen, and movements that felt impossible in week one become achievable by week four. This period is crucial for establishing the mind-body connection that serves as the foundation for the transformation to come.</p>
+            </div>
+
+            <div class="blog-section">
+                <h2 class="section-title">30 to 60 Days — Building Strength</h2>
+                <p>In the second month, the visible physical changes begin to take shape. Your muscle tone starts to improve as you hold poses for longer durations, engaging stabilizing muscles you may not have used before. This is the stage where "yoga strength" becomes evident—a functional, lean strength that supports your body in all daily activities.</p>
+                <p>Posture correction also becomes a significant highlight during this period. You'll find yourself sitting and standing taller naturally, as your core strength increases and your awareness of body alignment sharpens. For many, this is also when sustainable weight management begins, as the physical exertion combined with reduced cortisol levels helps the body find its natural balance.</p>
+            </div>
+
+            <div class="blog-section">
+                <h2 class="section-title">60 to 90 Days — Real Transformation</h2>
+                <p>By the third month, you are no longer just "doing yoga"—you have become a practitioner. Significant strength gains are now apparent, and you'll likely find yourself attempting more challenging poses with confidence. The consistency of your practice has rewired your physical capabilities, providing a level of endurance and stamina that extends far beyond the mat.</p>
+                <p>Mental clarity and hormonal balance often reach a peak during this stage. The cumulative effects of consistent practice help regulate internal systems, leading to more stable energy levels and emotional resilience. Most importantly, a sustainable fitness habit has been formed, making wellness a natural and enjoyable part of your lifestyle rather than a chore.</p>
+            </div>
+
+            <div class="blog-section">
+                <h2 class="section-title">Factors That Affect Your Progress</h2>
+                <p>Several factors influence how quickly you'll see transformation. Frequency is paramount—practicing daily for 20 minutes often yields faster results than one long session once a week. The style of yoga you choose, your nutritional habits, and ensuring adequate sleep all play vital roles in how your body recovers and adapts.</p>
+                <p>To see the best results, it's essential to have expert guidance that ensures proper alignment and progression. If you're ready to commit to your wellness, you can <a href="/Online-Yoga-Classes.html">join online yoga classes</a> with our certified instructors who will support you through every stage of your transformation.</p>
+            </div>
+
+            <div class="tip-box">
+                <p>Ready to start your transformation? <a href='/Online-Yoga-Classes.html'>Join our online yoga classes</a> at Zuga Fitness — first class free!</p>
+            </div>
+
+            <div class="author-section">
+                <div class="author-image">
+                    <img loading="lazy" src="https://images.unsplash.com/photo-1616683699101-ccf0d5d5a439?ixlib=rb-4.0.3&auto=format&fit=crop&w=200&q=80" alt="Mallinath B">
+                </div>
+                <div class="author-info">
+                    <h3>Mallinath B, Zuga Fitness</h3>
+                    <p>Expert in Hatha & Vinyasa with 1,500+ hours taught. Specializes in physical transformation and structural alignment through yoga.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Newsletter -->
+    <section class="newsletter">
+        <h3>Join Our Wellness Community</h3>
+        <p>Subscribe to receive exclusive yoga tips, class updates, and special offers</p>
+        <form class="subscribe-form">
+            <input type="email" placeholder="Your email address" required>
+            <button type="submit">Subscribe</button>
+        </form>
+    </section>
+
+    <!-- Footer -->
+    <footer>
+        <div class="footer-content">
+            <div class="footer-column">
+                <h3>Zuga Fitness</h3>
+                <p>Making yoga accessible and enjoyable for everyone. Join our community today and transform your practice.</p>
+                <div class="social-links">
+                    <a href="https://www.facebook.com/share/15zQqbzBEd/?mibextid=wwXIfr"><i class="fab fa-facebook-f"></i></a>
+                    <a href="https://www.instagram.com/zuga_fitness?igsh=cjgxaXcxOTRpdXhy&utm_source=qr"><i class="fab fa-instagram"></i></a>
+                    <a href="../index.html"><i class="fab fa-youtube"></i></a>
+                    <a href="../index.html"><i class="fab fa-pinterest"></i></a>
+                </div>
+            </div>
+
+            <div class="footer-column">
+                <h3>Quick Links</h3>
+                <ul class="footer-links">
+                    <li><a href="../index.html">Home</a></li>
+                    <li><a href="../Online-Yoga-Classes.html">Group Classes</a></li>
+                    <li><a href="../Online-Personal-Training-classes.html">Personal Training</a></li>
+                    <li><a href="../Online-Pranayama-Classes.html">Pranayama & Meditation</a></li>
+                    <li><a href="../Online-Yoga-Classes-For-PCOD.html">PCOD Yoga</a></li>
+                    <li><a href="../corporate-yoga-day-bangalore.html">Corporate Yoga Day</a></li>
+                </ul>
+            </div>
+
+            <div class="footer-column">
+                <h3>Blog Categories</h3>
+                <ul class="footer-links">
+                    <li><a href="morning-yoga-routine-for-energy.html">Beginner Tips</a></li>
+                    <li><a href="yoga-for-stress-relief.html">Mindfulness</a></li>
+                    <li><a href="yoga-poses-for-better-sleep.html">Breathwork</a></li>
+                    <li><a href="yoga-poses-for-pcod-management.html">Women's Health</a></li>
+                    <li><a href="yoga-for-seniors-online.html">Senior Wellness</a></li>
+                </ul>
+            </div>
+
+            <div class="footer-column">
+                <h3>Contact Us</h3>
+                <ul class="footer-links">
+                    <li><i class="fas fa-map-marker-alt"></i> Bangalore, India</li>
+                    <li><i class="fas fa-phone"></i> +91 76763 79909</li>
+                    <li><i class="fas fa-envelope"></i> zugafitness24@gmail.com</li>
+                </ul>
+            </div>
+        </div>
+
+        <div class="copyright">
+            <p>&copy; 2025 Zuga Fitness. All rights reserved.</p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/Blog/yoga-vs-gym.html
+++ b/Blog/yoga-vs-gym.html
@@ -1,0 +1,646 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Yoga vs gym — which should you choose? Complete comparison of benefits, weight loss, muscle building and mental health by Zuga Fitness experts.">
+    <meta name="keywords" content="yoga vs gym, yoga benefits, gym vs yoga for weight loss, mental health yoga, Zuga Fitness">
+    <meta name="author" content="Zuga Fitness">
+
+    <title>Yoga vs Gym — Which is Better for You? | Zuga Fitness</title>
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
+
+    <style>
+        :root {
+            --primary: #4a7c59;
+            --secondary: #8d9f87;
+            --accent: #d0b49f;
+            --light: #f4f1e9;
+            --dark: #2d3319;
+            --text: #333;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Poppins', sans-serif;
+            background-color: var(--light);
+            color: var(--text);
+            line-height: 1.7;
+        }
+
+        /* Header Styles */
+        header {
+            background-color: white;
+            box-shadow: 0 2px 15px rgba(0,0,0,0.1);
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            padding: 0 5%;
+        }
+
+        .navbar {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 1.2rem 0;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .logo-container {
+            display: flex;
+            align-items: center;
+            gap: 15px;
+        }
+
+        .logo {
+            height: 60px;
+            width: 60px;
+            border-radius: 50%;
+            background-color: var(--primary);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: white;
+            font-weight: 700;
+            font-size: 1.8rem;
+        }
+
+        .logo-text {
+            font-family: 'Playfair Display', serif;
+            font-size: 1.8rem;
+            font-weight: 700;
+            color: var(--primary);
+            letter-spacing: 1px;
+        }
+
+        .nav-links {
+            display: flex;
+            gap: 30px;
+        }
+
+        .nav-links a {
+            text-decoration: none;
+            color: var(--dark);
+            font-weight: 500;
+            font-size: 1.1rem;
+            transition: color 0.3s;
+            position: relative;
+        }
+
+        .nav-links a:hover {
+            color: var(--primary);
+        }
+
+        .nav-links a.active {
+            color: var(--primary);
+            font-weight: 600;
+        }
+
+        .nav-links a.active::after {
+            content: '';
+            position: absolute;
+            bottom: -5px;
+            left: 0;
+            width: 100%;
+            height: 3px;
+            background-color: var(--primary);
+            border-radius: 2px;
+        }
+
+        .cta-button {
+            background-color: var(--primary);
+            color: white;
+            border: none;
+            padding: 10px 25px;
+            border-radius: 30px;
+            font-size: 1rem;
+            font-weight: 500;
+            cursor: pointer;
+            transition: all 0.3s;
+            text-decoration: none;
+            display: inline-block;
+        }
+
+        .cta-button:hover {
+            background-color: #3a6547;
+            transform: translateY(-2px);
+            box-shadow: 0 4px 10px rgba(74, 124, 89, 0.3);
+        }
+
+        /* Breadcrumb */
+        .breadcrumb {
+            max-width: 1200px;
+            margin: 20px auto;
+            padding: 0 20px;
+            font-size: 0.9rem;
+        }
+
+        .breadcrumb a {
+            color: var(--primary);
+            text-decoration: none;
+        }
+
+        .breadcrumb a:hover {
+            text-decoration: underline;
+        }
+
+        /* Blog Content */
+        .blog-container {
+            max-width: 900px;
+            margin: 40px auto;
+            padding: 0 20px;
+        }
+
+        .blog-header {
+            text-align: center;
+            margin-bottom: 40px;
+        }
+
+        .blog-meta {
+            display: flex;
+            justify-content: center;
+            gap: 20px;
+            margin-bottom: 15px;
+            font-size: 0.95rem;
+            color: var(--secondary);
+        }
+
+        .blog-category {
+            background: var(--accent);
+            color: white;
+            padding: 3px 12px;
+            border-radius: 20px;
+            font-size: 0.85rem;
+            font-weight: 500;
+        }
+
+        .blog-title {
+            font-family: 'Playfair Display', serif;
+            font-size: 2.8rem;
+            margin-bottom: 20px;
+            color: var(--dark);
+            line-height: 1.2;
+        }
+
+        .blog-subtitle {
+            font-size: 1.3rem;
+            color: #555;
+            max-width: 700px;
+            margin: 0 auto 30px;
+            font-weight: 400;
+        }
+
+        .featured-image {
+            width: 100%;
+            height: 500px;
+            border-radius: 12px;
+            overflow: hidden;
+            margin-bottom: 40px;
+            position: relative;
+        }
+
+        .featured-image img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+        }
+
+        .blog-content {
+            background: white;
+            padding: 40px;
+            border-radius: 15px;
+            box-shadow: 0 5px 20px rgba(0,0,0,0.05);
+        }
+
+        .content-intro {
+            font-size: 1.1rem;
+            margin-bottom: 40px;
+            padding-bottom: 20px;
+            border-bottom: 1px solid #eee;
+        }
+
+        .blog-section {
+            margin-bottom: 40px;
+        }
+
+        .section-title {
+            font-family: 'Playfair Display', serif;
+            font-size: 1.8rem;
+            margin-bottom: 20px;
+            color: var(--primary);
+            position: relative;
+            padding-bottom: 10px;
+        }
+
+        .section-title::after {
+            content: '';
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            width: 60px;
+            height: 3px;
+            background-color: var(--accent);
+        }
+
+        .tip-box {
+            background: rgba(212, 237, 218, 0.3);
+            border-left: 4px solid var(--primary);
+            padding: 20px;
+            margin: 30px 0;
+            border-radius: 0 8px 8px 0;
+        }
+
+        .author-section {
+            display: flex;
+            gap: 20px;
+            align-items: center;
+            margin: 50px 0 30px;
+            padding: 20px;
+            background: rgba(208, 180, 159, 0.1);
+            border-radius: 12px;
+        }
+
+        .author-image {
+            width: 100px;
+            height: 100px;
+            border-radius: 50%;
+            overflow: hidden;
+        }
+
+        .author-image img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+        }
+
+        .author-info h3 {
+            font-size: 1.3rem;
+            margin-bottom: 5px;
+        }
+
+        .author-info p {
+            color: #666;
+            font-size: 0.95rem;
+        }
+
+        /* Newsletter */
+        .newsletter {
+            background: linear-gradient(to right, var(--primary), var(--secondary));
+            padding: 70px 0;
+            text-align: center;
+            color: white;
+            margin: 80px 0;
+        }
+
+        .newsletter h3 {
+            font-family: 'Playfair Display', serif;
+            font-size: 2.2rem;
+            margin-bottom: 20px;
+        }
+
+        .newsletter p {
+            max-width: 600px;
+            margin: 0 auto 30px;
+            font-size: 1.1rem;
+        }
+
+        .subscribe-form {
+            display: flex;
+            max-width: 500px;
+            margin: 0 auto;
+        }
+
+        .subscribe-form input {
+            flex: 1;
+            padding: 15px 20px;
+            border: none;
+            border-radius: 30px 0 0 30px;
+            font-size: 1rem;
+            outline: none;
+        }
+
+        .subscribe-form button {
+            background: var(--accent);
+            color: white;
+            border: none;
+            padding: 0 30px;
+            border-radius: 0 30px 30px 0;
+            font-weight: 500;
+            cursor: pointer;
+            transition: background 0.3s;
+        }
+
+        .subscribe-form button:hover {
+            background: #c0a088;
+        }
+
+        /* Footer */
+        footer {
+            background: var(--dark);
+            color: white;
+            padding: 60px 0 30px;
+        }
+
+        .footer-content {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 20px;
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 40px;
+        }
+
+        .footer-column h3 {
+            font-size: 1.3rem;
+            margin-bottom: 25px;
+            position: relative;
+            padding-bottom: 10px;
+        }
+
+        .footer-column h3::after {
+            content: '';
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            width: 50px;
+            height: 2px;
+            background: var(--accent);
+        }
+
+        .footer-links {
+            list-style: none;
+        }
+
+        .footer-links li {
+            margin-bottom: 12px;
+        }
+
+        .footer-links a {
+            color: #ccc;
+            text-decoration: none;
+            transition: color 0.3s;
+        }
+
+        .footer-links a:hover {
+            color: white;
+        }
+
+        .social-links {
+            display: flex;
+            gap: 15px;
+            margin-top: 20px;
+        }
+
+        .social-links a {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 40px;
+            height: 40px;
+            background: rgba(255,255,255,0.1);
+            border-radius: 50%;
+            color: white;
+            text-decoration: none;
+            transition: all 0.3s;
+        }
+
+        .social-links a:hover {
+            background: var(--accent);
+            transform: translateY(-3px);
+        }
+
+        .copyright {
+            text-align: center;
+            padding-top: 40px;
+            margin-top: 40px;
+            border-top: 1px solid rgba(255,255,255,0.1);
+            color: #aaa;
+            font-size: 0.9rem;
+        }
+
+        /* Responsive Design */
+        @media (max-width: 768px) {
+            .navbar {
+                flex-direction: column;
+                gap: 20px;
+                padding: 20px 0;
+            }
+
+            .nav-links {
+                gap: 15px;
+                flex-wrap: wrap;
+                justify-content: center;
+            }
+
+            .blog-title {
+                font-size: 2.3rem;
+            }
+
+            .featured-image {
+                height: 300px;
+            }
+
+            .blog-content {
+                padding: 30px 20px;
+            }
+
+            .author-section {
+                flex-direction: column;
+                text-align: center;
+            }
+        }
+    </style>
+  <link rel="canonical" href="https://zugafitness.in/Blog/yoga-vs-gym.html" />
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is yoga better than gym for weight loss?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Both yoga and gym can support weight loss effectively. The gym may burn more calories per session, but yoga supports weight management through stress reduction, hormonal balance and building a sustainable daily practice. Many people find yoga easier to maintain long-term."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can yoga replace gym workouts?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, yoga can completely replace gym workouts depending on your fitness goals. Power yoga and vinyasa yoga build significant strength and cardiovascular fitness. For pure muscle building, gym remains more effective, but yoga excels for overall wellness, flexibility and mental health."
+      }
+    }
+  ]
+}
+</script>
+
+</head>
+<body>
+    <!-- Header -->
+    <header>
+        <div class="navbar">
+            <div class="logo-container">
+                <div class="logo">Z</div>
+                <div class="logo-text">Zuga Fitness</div>
+            </div>
+
+             <div class="nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../Online-Yoga-Classes.html">Classes</a>
+                <a href="../pricing.html">Pricing</a>
+                <a href="../Blog/index.html">Blog</a>
+                <a href="../index.html#form02-6">Contact</a>
+            </div>
+
+            <a href="../free-trial.html" class="cta-button">Try Free Class</a>
+        </div>
+    </header>
+
+    <!-- Breadcrumb -->
+    <div class="breadcrumb">
+        <a href="../index.html">Home</a> / <a href="index.html">Blog</a> / Yoga vs Gym
+    </div>
+
+    <!-- Blog Content -->
+    <div class="blog-container">
+        <div class="blog-header">
+            <div class="blog-meta">
+                <span><i class="far fa-calendar"></i> May 15, 2026</span>
+                <span class="blog-category">Fitness Comparison</span>
+            </div>
+            <h1 class="blog-title">Yoga vs Gym — Which is Better for You?</h1>
+        </div>
+
+        <div class="featured-image">
+            <img loading="lazy" src="https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80" alt="Yoga vs Gym comparison">
+        </div>
+
+        <div class="blog-content">
+            <div class="content-intro">
+                <p>Deciding between starting a yoga practice or joining a gym is a common dilemma for anyone looking to improve their health. Both paths offer significant benefits, but they approach fitness from very different perspectives. Understanding these differences is key to choosing the path that aligns with your personal goals and lifestyle.</p>
+            </div>
+
+            <div class="blog-section">
+                <h2 class="section-title">Key Differences Between Yoga and Gym</h2>
+                <p>The primary difference lies in the approach to movement. A gym workout typically focuses on external results through resistance training and high-intensity cardiovascular exercise. The goal is often to isolate specific muscle groups to build size and power, or to push the heart rate into specific zones for calorie burning. It's a goal-oriented environment where progress is measured in weights lifted or miles run.</p>
+                <p>Yoga, conversely, is an internal practice that emphasizes the mind-body connection. While it certainly builds physical strength, it does so through functional, full-body movements and isometric holds. The focus is on flexibility, balance, and the coordination of movement with the breath. In yoga, the journey—staying present and aware—is just as important as the physical outcome.</p>
+            </div>
+
+            <div class="blog-section">
+                <h2 class="section-title">Yoga vs Gym for Weight Loss</h2>
+                <p>In terms of pure calorie burning during a single session, the gym often takes the lead. A high-intensity interval training (HIIT) session or a heavy lifting routine can burn a large number of calories in a short amount of time. If your primary goal is rapid, short-term weight loss and you enjoy high-intensity environments, the gym can be highly effective.</p>
+                <p>However, yoga offers a more sustainable approach to weight management long-term. By reducing cortisol—the stress hormone linked to abdominal fat—and improving hormonal balance, yoga helps regulate the body's natural weight. Furthermore, the mindfulness developed through yoga often leads to better nutritional choices and a more positive relationship with one's body, making the weight loss easier to maintain over years rather than months.</p>
+            </div>
+
+            <div class="blog-section">
+                <h2 class="section-title">Yoga vs Gym for Stress and Mental Health</h2>
+                <p>While any form of exercise helps reduce stress through the release of endorphins, yoga has a distinct advantage in the realm of mental health. The integration of pranayama (breathing techniques) and meditation directly stimulates the parasympathetic nervous system, shifting the body from a state of 'fight or flight' to 'rest and digest'.</p>
+                <p>The gym can sometimes be a source of additional stress, with its loud music, mirrors, and competitive atmosphere. Yoga provides a sanctuary for the mind, teaching practitioners how to remain calm under physical challenge—a skill that translates directly to managing life's daily stressors. For those seeking emotional resilience and mental clarity, yoga is the clear winner.</p>
+            </div>
+
+            <div class="blog-section">
+                <h2 class="section-title">Can You Do Both Yoga and Gym?</h2>
+                <p>Absolutely! In fact, yoga and gym workouts complement each other perfectly. Many professional athletes and bodybuilders use yoga for active recovery, flexibility, and injury prevention. The strength built in the gym can help you progress in advanced yoga poses, while the flexibility and core stability gained from yoga will improve your lifting form and protect your joints in the gym.</p>
+            </div>
+
+            <div class="blog-section">
+                <h2 class="section-title">Which is Right for You?</h2>
+                <p>Your choice depends on what your body and mind need right now:</p>
+                <ul class="benefits-list">
+                    <li><strong>Choose yoga if:</strong> you want to improve flexibility, seek significant stress relief, need to balance your hormones, prefer a gentle yet effective fitness routine, or have specific health needs like PCOD or postpartum recovery.</li>
+                    <li><strong>Choose gym if:</strong> your primary goal is building significant muscle mass, you thrive on high-intensity cardio, or you enjoy the social and equipment-heavy environment of a fitness center.</li>
+                </ul>
+                <p>If you're ready to experience the holistic benefits of yoga, you can explore our <a href="/Online-Yoga-Classes.html">online yoga classes</a> designed for all levels.</p>
+            </div>
+
+            <div class="tip-box">
+                <p>Curious about yoga? <a href='/Online-Yoga-Classes.html'>Try a free online yoga class</a> with Zuga Fitness and experience the difference.</p>
+            </div>
+
+            <div class="author-section">
+                <div class="author-image">
+                    <img loading="lazy" src="https://images.unsplash.com/photo-1573496359142-b8d87734a5a2?ixlib=rb-4.0.3&auto=format&fit=crop&w=200&q=80" alt="Anusha YP">
+                </div>
+                <div class="author-info">
+                    <h3>Anusha YP, Zuga Fitness</h3>
+                    <p>Specialist in women's wellness, PCOD, and postpartum yoga. Passionate about helping practitioners find balance and strength through mindful movement.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Newsletter -->
+    <section class="newsletter">
+        <h3>Join Our Wellness Community</h3>
+        <p>Subscribe to receive exclusive yoga tips, class updates, and special offers</p>
+        <form class="subscribe-form">
+            <input type="email" placeholder="Your email address" required>
+            <button type="submit">Subscribe</button>
+        </form>
+    </section>
+
+    <!-- Footer -->
+    <footer>
+        <div class="footer-content">
+            <div class="footer-column">
+                <h3>Zuga Fitness</h3>
+                <p>Making yoga accessible and enjoyable for everyone. Join our community today and transform your practice.</p>
+                <div class="social-links">
+                    <a href="https://www.facebook.com/share/15zQqbzBEd/?mibextid=wwXIfr"><i class="fab fa-facebook-f"></i></a>
+                    <a href="https://www.instagram.com/zuga_fitness?igsh=cjgxaXcxOTRpdXhy&utm_source=qr"><i class="fab fa-instagram"></i></a>
+                    <a href="../index.html"><i class="fab fa-youtube"></i></a>
+                    <a href="../index.html"><i class="fab fa-pinterest"></i></a>
+                </div>
+            </div>
+
+            <div class="footer-column">
+                <h3>Quick Links</h3>
+                <ul class="footer-links">
+                    <li><a href="../index.html">Home</a></li>
+                    <li><a href="../Online-Yoga-Classes.html">Group Classes</a></li>
+                    <li><a href="../Online-Personal-Training-classes.html">Personal Training</a></li>
+                    <li><a href="../Online-Pranayama-Classes.html">Pranayama & Meditation</a></li>
+                    <li><a href="../Online-Yoga-Classes-For-PCOD.html">PCOD Yoga</a></li>
+                    <li><a href="../corporate-yoga-day-bangalore.html">Corporate Yoga Day</a></li>
+                </ul>
+            </div>
+
+            <div class="footer-column">
+                <h3>Blog Categories</h3>
+                <ul class="footer-links">
+                    <li><a href="morning-yoga-routine-for-energy.html">Beginner Tips</a></li>
+                    <li><a href="yoga-for-stress-relief.html">Mindfulness</a></li>
+                    <li><a href="yoga-poses-for-better-sleep.html">Breathwork</a></li>
+                    <li><a href="yoga-poses-for-pcod-management.html">Women's Health</a></li>
+                    <li><a href="yoga-for-seniors-online.html">Senior Wellness</a></li>
+                </ul>
+            </div>
+
+            <div class="footer-column">
+                <h3>Contact Us</h3>
+                <ul class="footer-links">
+                    <li><i class="fas fa-map-marker-alt"></i> Bangalore, India</li>
+                    <li><i class="fas fa-phone"></i> +91 76763 79909</li>
+                    <li><i class="fas fa-envelope"></i> zugafitness24@gmail.com</li>
+                </ul>
+            </div>
+        </div>
+
+        <div class="copyright">
+            <p>&copy; 2025 Zuga Fitness. All rights reserved.</p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -214,4 +214,16 @@
     <priority>0.7</priority>
   </url>
 
+  <url>
+    <loc>https://zugafitness.in/Blog/how-long-yoga-takes-to-transform-your-body.html</loc>
+    <lastmod>2026-05-15</lastmod>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://zugafitness.in/Blog/yoga-vs-gym.html</loc>
+    <lastmod>2026-05-15</lastmod>
+    <priority>0.7</priority>
+  </url>
+
 </urlset>


### PR DESCRIPTION
I have restored the full content for two blog posts in the `/Blog/` directory that were previously just redirect stubs. Specifically:

1.  **`Blog/how-long-yoga-takes-to-transform-your-body.html`**:
    *   Removed redirect code.
    *   Added full blog content with H1, H2s, and internal links.
    *   Added canonical tag: `https://zugafitness.in/Blog/how-long-yoga-takes-to-transform-your-body.html`.
    *   Included JSON-LD FAQ schema.

2.  **`Blog/yoga-vs-gym.html`**:
    *   Removed redirect code.
    *   Added full comparison content between yoga and gym workouts.
    *   Added canonical tag: `https://zugafitness.in/Blog/yoga-vs-gym.html`.
    *   Included JSON-LD FAQ schema.

3.  **`sitemap.xml`**:
    *   Added both new blog URLs with `<lastmod>2026-05-15</lastmod>` and `<priority>0.7</priority>`.

Both pages were verified using Playwright to ensure they match the site's existing styling and layout.

---
*PR created automatically by Jules for task [16927412045432474812](https://jules.google.com/task/16927412045432474812) started by @ZugaFitness*