### PR TITLE
IYD — Yoga Week Update

### DIFF
--- a/Blog/corporate-yoga-day-bangalore.html
+++ b/Blog/corporate-yoga-day-bangalore.html
@@ -977,8 +977,8 @@
     <div class="row align-items-center">
       <!-- Left Grid Content -->
       <div class="col-lg-6 mb-5 mb-lg-0">
-        <h1 class="display-3 mb-4" style="font-family: 'Playfair Display', serif; font-weight: 700;">Celebrate International Yoga Day on Your Terms.</h1>
-        <p class="mb-5" style="font-family: 'Poppins', sans-serif; font-weight: 300; font-size: 1.25rem; color: var(--brand-text);">Don't force your employees to log in on a weekend. Bring Bangalore’s premier, lineage-trained instructors directly to your physical office floor during Corporate Yoga Week (June 16–25).</p>
+        <h1 class="display-3 mb-4" style="font-family: 'Playfair Display', serif; font-weight: 700;">Corporate Yoga Week <br>— June 16 to 25, 2026</h1>
+        <p class="mb-5" style="font-family: 'Poppins', sans-serif; font-weight: 300; font-size: 1.25rem; color: var(--brand-text);">International Yoga Day falls on a Sunday this year. <br>So we're doing the whole week. <br>Pick any date — we come to you.</p>
         <div class="mbr-section-btn">
           <a class="btn btn-brand-cta display-4" href="#pricing" style="border-radius: 50px !important; box-shadow: 0 8px 20px var(--brand-orange-shadow);">Explore Corporate Plans</a>
         </div>
@@ -1014,7 +1014,7 @@
 <section class="scarcity-banner" style="background: var(--brand-white); border-top: 1px solid var(--brand-orange); border-bottom: 1px solid var(--brand-orange); padding: 25px 0;">
   <div class="container">
     <p class="mb-0 text-center" style="font-family: 'Poppins', sans-serif; font-weight: 600; color: var(--brand-text); font-size: 1.1rem; letter-spacing: 0.5px;">
-      ⚠️ CAPACITY ALERT: To preserve absolute, elite instruction quality, we limit our schedule to strictly 4 office slots per day across Bangalore. Peak workspace windows (9 AM and 6 PM) are filling rapidly.
+      ⚠️ Only 2 slots remaining for June 16–25
     </p>
   </div>
 </section>
@@ -1031,7 +1031,7 @@
               <svg width="30" height="30" viewBox="0 0 24 24" fill="none" stroke="var(--brand-teal)" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
             </div>
             <h3 class="mb-3" style="font-family: 'Playfair Display', serif; font-size: 1.5rem;">Logistical Relief</h3>
-            <p style="font-family: 'Poppins', sans-serif; font-weight: 400; color: var(--brand-text); font-size: 0.95rem;">June 21 lands on a Sunday this year. We bring the corporate pop-up directly to your office on weekdays so employee personal time is fully respected.</p>
+            <p style="font-family: 'Poppins', sans-serif; font-weight: 400; color: var(--brand-text); font-size: 0.95rem;">International Yoga Day falls on a Sunday this year. We bring the corporate pop-up directly to your office on weekdays (June 16–25) so employee personal time is fully respected.</p>
           </div>
         </div>
         <!-- Column 2 Card -->
@@ -1356,7 +1356,7 @@
           <div class="faq-item" style="border-bottom: none;">
             <div class="faq-question" data-bs-toggle="collapse" data-bs-target="#faq5">Why is it "Corporate Yoga Week"? <span class="faq-icon-3d">+</span></div>
             <div id="faq5" class="collapse faq-answer-3d">
-              <p class="py-3">Since International Yoga Day (June 21) falls on a Sunday this year, we've extended our onsite availability from June 16 to June 25. This allows your team to participate during regular work hours on a weekday that suits your schedule best.</p>
+              <p class="py-3">Since International Yoga Day falls on a Sunday this year, we've extended our onsite availability to June 16–25. This allows your team to participate during regular work hours on a weekday that suits your schedule best.</p>
             </div>
           </div>
         </div>
@@ -1374,7 +1374,7 @@
     <svg viewBox="0 0 100 100" fill="white"><path d="M50 10 L90 90 L10 90 Z" opacity="0.2"></path></svg>
   </div>
   <div class="container" style="position: relative; z-index: 1;">
-    <h2 class="display-3 mb-4 text-white">We host strictly 4 onsite office slots per day across Bangalore to ensure our premium senior instructors can manage the energy of each floor.</h2>
+    <h2 class="display-3 mb-4 text-white">Only 2 slots remaining for June 16–25</h2>
     <p class="lead mb-5 text-white brand-sans">Bangalore companies are booking fast for Corporate Yoga Week (June 16–25). Slots for peak corporate hours (9 AM and 6 PM) are filling up fast — don't miss out.</p>
     <div class="mbr-section-btn">
       <a class="btn btn-brand-cta display-4 lift-3d" style="background-color: white !important; color: var(--brand-orange) !important;" href="#onsite">Check Availability Now</a>

--- a/Blog/hire-yoga-trainer-yoga-day-bangalore.html
+++ b/Blog/hire-yoga-trainer-yoga-day-bangalore.html
@@ -661,7 +661,7 @@
                 <span class="blog-category">Corporate Wellness</span>
             </div>
             <h1 class="blog-title">How to Hire a Yoga Trainer for International Yoga Day in Bangalore (2026)</h1>
-            <p class="blog-subtitle">Since International Yoga Day (June 21) falls on a Sunday this year, Bangalore HR teams are shifting to <strong>Corporate Yoga Week (June 16–25)</strong>. Here is how to hire the right trainer for your weekday office session.</p>
+            <p class="blog-subtitle">Since International Yoga Day falls on a Sunday this year, Bangalore HR teams are shifting to <strong>Corporate Yoga Week (June 16–25)</strong>. Here is how to hire the right trainer for your weekday office session.</p>
         </div>
 
         <div class="featured-image">

--- a/Blog/yoga-day-activities-office-bangalore.html
+++ b/Blog/yoga-day-activities-office-bangalore.html
@@ -661,12 +661,12 @@
                 <span class="blog-category">Corporate Wellness</span>
             </div>
             <h1 class="blog-title">5 Yoga Day Activities Your Bangalore Office Will Actually Enjoy (2026)</h1>
-            <p class="blog-subtitle">International Yoga Day falls on June 21 — which is a Sunday this year. To help HR managers, Zuga Fitness is hosting <strong>Corporate Yoga Week (June 16–25)</strong> so your team can participate during regular office hours.</p>
+            <p class="blog-subtitle">International Yoga Day falls on a Sunday this year. To help HR managers, Zuga Fitness is hosting <strong>Corporate Yoga Week (June 16–25)</strong> so your team can participate during regular office hours.</p>
         </div>
 
         <div class="featured-image">
             <img loading="lazy" src="https://images.unsplash.com/photo-1522071820081-009f0129c71c?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80" alt="Team doing yoga together in a Bangalore office on International Yoga Day">
-            <div class="image-caption">International Yoga Day is June 21 — here's how Bangalore offices are celebrating during Corporate Yoga Week</div>
+            <div class="image-caption">International Yoga Day falls on a Sunday this year — here's how Bangalore offices are celebrating during Corporate Yoga Week (June 16–25)</div>
         </div>
 
         <div class="blog-content">

--- a/corporate-yoga-day-bangalore.html
+++ b/corporate-yoga-day-bangalore.html
@@ -1062,8 +1062,8 @@
     <div class="row align-items-center">
       <!-- Left Grid Content -->
       <div class="col-lg-6 mb-5 mb-lg-0">
-        <h1 class="display-3 mb-4" style="font-family: 'Playfair Display', serif; font-weight: 700;">Celebrate International Yoga Day on Your Terms.</h1>
-        <p class="mb-5" style="font-family: 'Poppins', sans-serif; font-weight: 300; font-size: 1.25rem; color: var(--brand-text);">Don't force your employees to log in on a weekend. Bring Bangalore’s premier, lineage-trained instructors directly to your physical office floor during Corporate Yoga Week (June 16–25).</p>
+        <h1 class="display-3 mb-4" style="font-family: 'Playfair Display', serif; font-weight: 700;">Corporate Yoga Week <br>— June 16 to 25, 2026</h1>
+        <p class="mb-5" style="font-family: 'Poppins', sans-serif; font-weight: 300; font-size: 1.25rem; color: var(--brand-text);">International Yoga Day falls on a Sunday this year. <br>So we're doing the whole week. <br>Pick any date — we come to you.</p>
         <div class="mbr-section-btn">
           <a class="btn btn-brand-cta display-4" href="#pricing" style="border-radius: 50px !important; box-shadow: 0 8px 20px var(--brand-orange-shadow);">Explore Corporate Plans</a>
         </div>
@@ -1099,7 +1099,7 @@
 <section class="scarcity-banner" style="background: var(--brand-white); border-top: 1px solid var(--brand-orange); border-bottom: 1px solid var(--brand-orange); padding: 25px 0;">
   <div class="container">
     <p class="mb-0 text-center" style="font-family: 'Poppins', sans-serif; font-weight: 600; color: var(--brand-text); font-size: 1.1rem; letter-spacing: 0.5px;">
-      ⚠️ CAPACITY ALERT: To preserve absolute, elite instruction quality, we limit our schedule to strictly 4 office slots per day across Bangalore. Peak workspace windows (9 AM and 6 PM) are filling rapidly.
+      ⚠️ Only 2 slots remaining for June 16–25
     </p>
   </div>
 </section>
@@ -1116,7 +1116,7 @@
               <svg width="30" height="30" viewBox="0 0 24 24" fill="none" stroke="var(--brand-teal)" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
             </div>
             <h3 class="mb-3" style="font-family: 'Playfair Display', serif; font-size: 1.5rem;">Logistical Relief</h3>
-            <p style="font-family: 'Poppins', sans-serif; font-weight: 400; color: var(--brand-text); font-size: 0.95rem;">June 21 lands on a Sunday this year. We bring the corporate pop-up directly to your office on weekdays so employee personal time is fully respected.</p>
+            <p style="font-family: 'Poppins', sans-serif; font-weight: 400; color: var(--brand-text); font-size: 0.95rem;">International Yoga Day falls on a Sunday this year. We bring the corporate pop-up directly to your office on weekdays (June 16–25) so employee personal time is fully respected.</p>
           </div>
         </div>
         <!-- Column 2 Card -->
@@ -1441,7 +1441,7 @@
           <div class="faq-item" style="border-bottom: none;">
             <div class="faq-question" data-bs-toggle="collapse" data-bs-target="#faq5">Why is it "Corporate Yoga Week"? <span class="faq-icon-3d">+</span></div>
             <div id="faq5" class="collapse faq-answer-3d">
-              <p class="py-3">Since International Yoga Day (June 21) falls on a Sunday this year, we've extended our onsite availability from June 16 to June 25. This allows your team to participate during regular work hours on a weekday that suits your schedule best.</p>
+              <p class="py-3">Since International Yoga Day falls on a Sunday this year, we've extended our onsite availability to June 16–25. This allows your team to participate during regular work hours on a weekday that suits your schedule best.</p>
             </div>
           </div>
         </div>
@@ -1459,7 +1459,7 @@
     <svg viewBox="0 0 100 100" fill="white"><path d="M50 10 L90 90 L10 90 Z" opacity="0.2"></path></svg>
   </div>
   <div class="container" style="position: relative; z-index: 1;">
-    <h2 class="display-3 mb-4 text-white">We host strictly 4 onsite office slots per day across Bangalore to ensure our premium senior instructors can manage the energy of each floor.</h2>
+    <h2 class="display-3 mb-4 text-white">Only 2 slots remaining for June 16–25</h2>
     <p class="lead mb-5 text-white brand-sans">Bangalore companies are booking fast for Corporate Yoga Week (June 16–25). Slots for peak corporate hours (9 AM and 6 PM) are filling up fast — don't miss out.</p>
     <div class="mbr-section-btn">
       <a class="btn btn-brand-cta display-4 lift-3d" style="background-color: white !important; color: var(--brand-orange) !important;" href="#onsite">Check Availability Now</a>

--- a/corporate-yoga-day.html
+++ b/corporate-yoga-day.html
@@ -685,7 +685,7 @@
 <!-- Section 9: Final CTA -->
 <section class="final-cta" id="contact">
   <div class="container">
-    <h2 class="display-3 mb-4">Only 4 Slots Left for June 21<br>International Yoga Day</h2>
+    <h2 class="display-3 mb-4">Only 2 slots remaining for June 16–25</h2>
     <p class="lead mb-0">Early bird deadline is approaching fast.</p>
     <div id="countdown">Loading...</div>
     <div class="mbr-section-btn">


### PR DESCRIPTION
This PR updates the International Yoga Day marketing materials to focus on "Corporate Yoga Week" (June 16–25, 2026) since the actual day falls on a Sunday. 

Key changes:
1. **Headline Update:** Changed to "Corporate Yoga Week — June 16 to 25, 2026".
2. **Subheadline Update:** Added context about the Sunday scheduling and week-long availability.
3. **Urgency Line Update:** Reduced remaining slots to 2 and updated the date range.
4. **Global Sync:** Replaced all text-based "June 21" references with "June 16–25" in `corporate-yoga-day-bangalore.html` (root and Blog), `corporate-yoga-day.html`, and two related blog posts.
5. **SEO/Schema:** Maintained technical schema dates at June 21 for search engine accuracy while updating marketing copy for user conversion.

The changes have been visually verified via Playwright screenshot.

---
*PR created automatically by Jules for task [6997764930697424679](https://jules.google.com/task/6997764930697424679) started by @ZugaFitness*