### PR TITLE
Fix 404 errors - portfolio and personal training pages

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -64,6 +64,20 @@
   </url>
 
   <url>
+    <loc>https://zugafitness.in/Mallinath-Portfolio.html</loc>
+    <lastmod>2026-06-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://zugafitness.in/Anusha-Portfolio.html</loc>
+    <lastmod>2026-06-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
     <loc>https://zugafitness.in/Virtual-Yoga-Classes-For-senior.html</loc>
     <lastmod>2026-06-10</lastmod>
     <priority>0.8</priority>


### PR DESCRIPTION
Adds the missing `Mallinath-Portfolio.html` and `Anusha-Portfolio.html` files to `sitemap.xml`. Verified that internal links already point correctly to the hyphenated file names, avoiding 404 errors.

---
*PR created automatically by Jules for task [4022232348036760726](https://jules.google.com/task/4022232348036760726) started by @ZugaFitness*