### PR TITLE
🧹 Remove actionable comment from free-trial.html

### DIFF
--- a/free-trial.html
+++ b/free-trial.html
@@ -1,4 +1,3 @@
-<!-- IMPORTANT: Replace mnjlyoqr in the form action below with your actual Formspree endpoint from formspree.io -->
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the presence of an outdated actionable comment (`<!-- IMPORTANT: Replace mnjlyoqr in the form action below with your actual Formspree endpoint from formspree.io -->`) at the top of the `free-trial.html` file.
💡 **Why:** This improves maintainability by removing obsolete instructions that may confuse future developers, since the correct endpoint (`mnjlyoqr`) is already implemented.
✅ **Verification:** I confirmed the change is safe by asking the user to verify the endpoint is correct and running `git diff` to ensure only the comment was removed without touching any functionality or other files (like `personal-training-consultation.html`).
✨ **Result:** A cleaner HTML file without lingering actionable comments.

---
*PR created automatically by Jules for task [13994355994679101693](https://jules.google.com/task/13994355994679101693) started by @ZugaFitness*