### PR TITLE
Add Service & LocalBusiness JSON-LD Schema

### DIFF
--- a/Online-Hatha-Vinyasa-Classes.html
+++ b/Online-Hatha-Vinyasa-Classes.html
@@ -306,6 +306,28 @@
     }
     </script>
   <link rel="stylesheet" href="assets/whatsapp.css">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    "serviceType": "Online Hatha Vinyasa Yoga Classes",
+    "provider": {
+      "@type": "LocalBusiness",
+      "name": "Zuga Fitness",
+      "url": "https://zugafitness.in"
+    },
+    "description": "Join our Hatha & Vinyasa Yoga online classes designed for balance strength and flexibility. Real-time instruction, all timezones. First class free.",
+    "areaServed": {
+      "@type": "Country",
+      "name": ["India", "United Kingdom", "United States", "UAE", "Australia", "Canada"]
+    },
+    "availableChannel": {
+      "@type": "ServiceChannel",
+      "serviceUrl": "https://zugafitness.in/Online-Hatha-Vinyasa-Classes.html"
+    }
+  }
+  </script>
 </head>
 <body>
 

--- a/Online-Yoga-Classes-For-PCOD.html
+++ b/Online-Yoga-Classes-For-PCOD.html
@@ -362,6 +362,28 @@
   </script>
   <script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"></script>
   <link rel="stylesheet" href="assets/whatsapp.css">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    "serviceType": "Online Yoga Classes for PCOD",
+    "provider": {
+      "@type": "LocalBusiness",
+      "name": "Zuga Fitness",
+      "url": "https://zugafitness.in"
+    },
+    "description": "Manage PCOD naturally with targeted online yoga classes. Expert-guided sessions at Zuga Fitness. Book your free trial class today.",
+    "areaServed": {
+      "@type": "Country",
+      "name": ["India", "United Kingdom", "United States", "UAE", "Australia", "Canada"]
+    },
+    "availableChannel": {
+      "@type": "ServiceChannel",
+      "serviceUrl": "https://zugafitness.in/Online-Yoga-Classes-For-PCOD.html"
+    }
+  }
+  </script>
 </head>
 <body>
 

--- a/free-trial.html
+++ b/free-trial.html
@@ -91,6 +91,28 @@
 
 
     <meta name="robots" content="index, follow">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    "serviceType": "Free Trial Consultation",
+    "provider": {
+      "@type": "LocalBusiness",
+      "name": "Zuga Fitness",
+      "url": "https://zugafitness.in"
+    },
+    "description": "Book your free live yoga class with Zuga Fitness. Choose your timezone, your style, your level. No credit card. Just show up with a mat.",
+    "areaServed": {
+      "@type": "Country",
+      "name": ["India", "United Kingdom", "United States", "UAE", "Australia", "Canada"]
+    },
+    "availableChannel": {
+      "@type": "ServiceChannel",
+      "serviceUrl": "https://zugafitness.in/free-trial.html"
+    }
+  }
+  </script>
 </head>
 <body>
     <section data-bs-version="5.1" class="menu menu2 cid-uEEJbxSjp1" once="menu" id="menu-5-uEEJbxSjp1">

--- a/index.html
+++ b/index.html
@@ -543,6 +543,47 @@
   <link rel="stylesheet" href="assets/whatsapp.css">
   <!-- Trustpilot Review Script -->
   <script type="text/javascript" src="//widget.trustpilot.com/bootstrap/v5/tp.widget.bootstrap.min.js" async></script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    "name": "Zuga Fitness",
+    "description": "Live Online Yoga Classes | Expert Instructors | 500+ Students Worldwide",
+    "url": "https://zugafitness.in",
+    "logo": "https://zugafitness.in/assets/logo.png",
+    "image": "https://images.unsplash.com/photo-1544367567-0f2fcb009e0b?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80",
+    "telephone": "+91-7676379909",
+    "email": "zugafitness24@gmail.com",
+    "address": {
+      "@type": "PostalAddress",
+      "addressCountry": "IN"
+    },
+    "geo": {
+      "@type": "GeoCoordinates",
+      "latitude": "12.9716",
+      "longitude": "77.5946"
+    },
+    "openingHoursSpecification": {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": [
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday"
+      ],
+      "opens": "06:00",
+      "closes": "21:00"
+    },
+    "priceRange": "$$",
+    "sameAs": [
+      "https://www.facebook.com/share/15zQqbzBEd/?mibextid=wwXIfr",
+      "https://www.instagram.com/zugafitness/"
+    ]
+  }
+  </script>
 </head>
 <script>
   document.addEventListener("DOMContentLoaded", function() {

--- a/personal-training-consultation.html
+++ b/personal-training-consultation.html
@@ -130,6 +130,28 @@
   </style>
 
     <meta name="robots" content="index, follow">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    "serviceType": "Personal Training Consultation",
+    "provider": {
+      "@type": "LocalBusiness",
+      "name": "Zuga Fitness",
+      "url": "https://zugafitness.in"
+    },
+    "description": "Standardized B2B wellness tracks for remote and hybrid corporate teams. Flat rates for up to 50 employees. Request a proposal.",
+    "areaServed": {
+      "@type": "Country",
+      "name": ["India", "United Kingdom", "United States", "UAE", "Australia", "Canada"]
+    },
+    "availableChannel": {
+      "@type": "ServiceChannel",
+      "serviceUrl": "https://zugafitness.in/personal-training-consultation.html"
+    }
+  }
+  </script>
 </head>
 <body>
     <section data-bs-version="5.1" class="menu menu2 cid-uEEJbxSjp1" once="menu" id="menu-5-uEEJbxSjp1">


### PR DESCRIPTION
Adds `LocalBusiness` JSON-LD schema to the homepage and `Service` JSON-LD schema to four core service pages (`Online-Yoga-Classes-For-PCOD.html`, `Online-Hatha-Vinyasa-Classes.html`, `personal-training-consultation.html`, and `free-trial.html`) to improve SEO and business entity recognition.

Changes ensure:
- `LocalBusiness` uses correct homepage phone number (`+91-7676379909`).
- `Service` schema `serviceType` perfectly matches `<title>` tag.
- `Service` schema `description` directly references the page's `<meta name="description">` tag.
- Dynamic `serviceUrl` maps precisely to each service page.
- Existing schemas and file contents remain unaltered and structured perfectly inside `</head>`.

---
*PR created automatically by Jules for task [277917855986976136](https://jules.google.com/task/277917855986976136) started by @ZugaFitness*