### PR TITLE
feat: Add long-term membership discount visibility across the site

### DIFF
--- a/Online-Yoga-Classes.html
+++ b/Online-Yoga-Classes.html
@@ -781,6 +781,20 @@
   </div>
 </section>
 
+<!-- LONG TERM DISCOUNT BANNER -->
+<section style="background-color: #FFFaf2; padding: 20px 0; border-top: 1px solid rgba(232, 105, 10, 0.2); border-bottom: 1px solid rgba(232, 105, 10, 0.2);">
+  <div class="container">
+    <div class="row justify-content-center text-center">
+      <div class="col-12">
+        <div class="mbr-fonts-style display-7" style="color: #0B6E6E; font-weight: 600; display: flex; align-items: center; justify-content: center; gap: 10px;">
+          <i data-lucide="sparkles" style="width: 20px; color: #E8690A;"></i>
+          <span>Save 20% on all plans with our <a href="https://zugafitness.in/pricing.html" style="color: #E8690A; text-decoration: underline;">long-term membership discounts</a>!</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
 <!-- REGISTRATION SECTION -->
 <section class="registration-section">
   <div class="container">

--- a/free-trial.html
+++ b/free-trial.html
@@ -256,6 +256,13 @@
 
                       <p class="form-reassurance">✅ Live instructor, not a recording &nbsp;·&nbsp; ✅ Any device, just need a mat &nbsp;·&nbsp; ✅ No commitment</p>
 
+                      <div style="background-color: #FFFaf2; border: 1px solid rgba(232, 105, 10, 0.2); border-radius: 8px; padding: 15px; margin-top: 20px; text-align: center;">
+                          <div class="mbr-fonts-style display-7" style="color: #0B6E6E; font-weight: 600; display: flex; align-items: center; justify-content: center; gap: 8px; font-size: 0.9rem;">
+                              <i data-lucide="sparkles" style="width: 18px; color: #E8690A;"></i>
+                              <span><strong>Looking to commit?</strong> Save 20% on all plans with our <a href="https://zugafitness.in/pricing.html" style="color: #E8690A; text-decoration: underline;">long-term membership discounts</a>!</span>
+                          </div>
+                      </div>
+
                       <!-- Inline success message (fallback if redirect fails) -->
                       <div id="form-success" style="display:none;">
                         <p>🎉 You're in! We'll WhatsApp or email you within 24 hours with your class details.</p>

--- a/index.html
+++ b/index.html
@@ -705,6 +705,20 @@
   </div>
 </div>
 
+<!-- LONG TERM DISCOUNT BANNER -->
+<section style="background-color: #FFFaf2; padding: 20px 0; border-bottom: 1px solid rgba(232, 105, 10, 0.2);">
+  <div class="container">
+    <div class="row justify-content-center text-center">
+      <div class="col-12">
+        <div class="mbr-fonts-style display-7" style="color: #0B6E6E; font-weight: 600; display: flex; align-items: center; justify-content: center; gap: 10px;">
+          <i data-lucide="sparkles" style="width: 20px; color: #E8690A;"></i>
+          <span>Save 20% on all plans with our <a href="https://zugafitness.in/pricing.html" style="color: #E8690A; text-decoration: underline;">long-term membership discounts</a>!</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
 <!-- QUICK ACCESS SECTION -->
 <section style="background-color: #FFFFFF; padding: 40px 0; border-bottom: 1px solid rgba(0,0,0,0.05);">
   <div class="container">

--- a/pricing.html
+++ b/pricing.html
@@ -316,6 +316,14 @@
           "@type": "Answer",
           "text": "No experience is required. We have beginner-friendly and advanced classes available."
         }
+      },
+      {
+        "@type": "Question",
+        "name": "Do you offer long-term membership discounts?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes, we offer long-term membership discounts! When you commit to any of our annual plans, you save 20% compared to the regular monthly rate."
+        }
       }
     ]
   }
@@ -725,6 +733,19 @@
                         <div id="collapse6" class="collapse" data-parent="#pricing-faq">
                             <div class="card-body mbr-fonts-style display-7">
                                 Just a yoga mat, a stable internet connection, and a device to join the live session (laptop, tablet, or smartphone).
+                            </div>
+                        </div>
+                    </div>
+                    <div class="card mb-3" style="border: none; border-bottom: 1px solid #eee; border-radius: 0;">
+                        <div class="card-header p-0" id="faq7">
+                            <button class="btn btn-link w-100 text-left d-flex justify-content-between align-items-center" type="button" data-toggle="collapse" data-target="#collapse7" style="text-decoration: none; color: black; padding: 20px;">
+                                <span class="mbr-fonts-style display-5" style="font-size: 1.3rem;">Do you offer long-term membership discounts?</span>
+                                <span>+</span>
+                            </button>
+                        </div>
+                        <div id="collapse7" class="collapse" data-parent="#pricing-faq">
+                            <div class="card-body mbr-fonts-style display-7">
+                                Yes, we offer long-term membership discounts! When you commit to any of our annual plans, you save 20% compared to the regular monthly rate.
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Added explicit references to the 20% long-term membership discount on annual plans across key pages of the website to improve visibility for users and AI assistants.

Changes include:
* **Pricing Page:** Added a new FAQ item answering "Do you offer long-term membership discounts?" explicitly mentioning the 20% discount on annual plans. Also updated the JSON-LD `FAQPage` schema to include this question and answer.
* **Home Page:** Added a promotional banner to `index.html` highlighting the 20% discount on annual plans.
* **Free Trial Page:** Added a promotional callout to `free-trial.html` highlighting the discount.
* **Class Pages:** Added promotional banners to all class pages (e.g., `Online-Yoga-Classes.html`, `Online-Dance-Fitness-Classes.html`, etc.) highlighting the 20% long-term discount.

---
*PR created automatically by Jules for task [14722522193497524633](https://jules.google.com/task/14722522193497524633) started by @ZugaFitness*