### PR TITLE
Assign Unique Hero Images to All Blog Posts

### DIFF
--- a/Blog/biomechanics-online-hatha-yoga-desk-slouch.html
+++ b/Blog/biomechanics-online-hatha-yoga-desk-slouch.html
@@ -655,7 +655,7 @@
         </div>
 
         <div class="featured-image">
-            <img loading="lazy" src="https://images.unsplash.com/photo-1593164842264-854604db2260?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80" alt="Live online yoga class interaction">
+            <img loading="lazy" src="https://images.unsplash.com/photo-1552072805-2a9039d00e57?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Live online yoga class interaction">
             <div class="image-caption">Interactive sessions bridge the gap between home practice and studio energy</div>
         </div>
 

--- a/Blog/corporate-yoga-day-bangalore.html
+++ b/Blog/corporate-yoga-day-bangalore.html
@@ -1018,7 +1018,7 @@
       <!-- Right Grid Content -->
       <div class="col-lg-6">
         <div class="hero-visual-container" style="background: var(--brand-white); padding: 20px; border-radius: 24px; box-shadow: 0 20px 40px rgba(0,0,0,0.06);">
-          <img src="https://images.unsplash.com/photo-1534438327276-14e5300c3a48?auto=format&fit=crop&w=1200&q=80" alt="Modern Corporate Workspace" style="width: 100%; border-radius: 16px; display: block;" loading="lazy">
+          <img src="https://images.unsplash.com/photo-1600881333168-2ef49b341f30?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Modern Corporate Workspace" style="width: 100%; border-radius: 16px; display: block;" loading="lazy">
         </div>
       </div>
     </div>

--- a/Blog/dance-fitness-vs-gym-calories.html
+++ b/Blog/dance-fitness-vs-gym-calories.html
@@ -657,7 +657,7 @@
         </div>
 
         <div class="featured-image">
-            <img loading="lazy" src="../assets/images/dance-workshop-team-building.jpg" alt="Dance Fitness Vs Gym Weight Loss">
+            <img loading="lazy" src="https://images.unsplash.com/photo-1508215885820-4585e56135c8?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Dance Fitness Vs Gym Weight Loss">
             <div class="image-caption">High-energy dance sessions bridge the gap between fat loss and mental clarity</div>
         </div>
 

--- a/Blog/hatha-vs-vinyasa-yoga.html
+++ b/Blog/hatha-vs-vinyasa-yoga.html
@@ -13,7 +13,7 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:title" content="Hatha vs Vinyasa Yoga: Which Style Is Right for You? | Zuga Fitness">
     <meta property="og:description" content="Hatha vs Vinyasa yoga: which style is right for you? Complete guide to choosing the best yoga style for your body & goals.">
-    <meta property="og:image" content="https://images.unsplash.com/photo-1506126613408-eca07ce68773?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80">
+    <meta property="og:image" content="https://images.unsplash.com/photo-1609342122563-a43acbc32f5a?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80">
     <meta property="og:url" content="https://zugafitness.in/Blog/hatha-vs-vinyasa-yoga.html">
     <meta property="og:type" content="article">
 
@@ -21,7 +21,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Hatha vs Vinyasa Yoga: Which Style Is Right for You? | Zuga Fitness">
     <meta name="twitter:description" content="Hatha vs Vinyasa yoga: which style is right for you? Complete guide to choosing the best yoga style for your body & goals.">
-    <meta name="twitter:image" content="https://images.unsplash.com/photo-1506126613408-eca07ce68773?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80">
+    <meta name="twitter:image" content="https://images.unsplash.com/photo-1609342122563-a43acbc32f5a?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80">
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
@@ -694,7 +694,7 @@
         </div>
 
         <div class="featured-image">
-            <img loading="lazy" src="https://images.unsplash.com/photo-1506126613408-eca07ce68773?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80" alt="Woman choosing between hatha and vinyasa yoga styles">
+            <img loading="lazy" src="https://images.unsplash.com/photo-1609342122563-a43acbc32f5a?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Woman choosing between hatha and vinyasa yoga styles">
             <div class="image-caption">The right yoga style depends on your body, goals, and energy levels</div>
         </div>
 

--- a/Blog/index.html
+++ b/Blog/index.html
@@ -706,7 +706,7 @@
             <!-- Trending Yoga -->
             <a href="hatha-vs-vinyasa-yoga.html" class="blog-card">
                 <div class="blog-image">
-                    <img src="https://images.unsplash.com/photo-1544367567-0f2fcb009e0b?w=600&h=400&fit=crop" alt="Woman practicing online yoga at home on her laptop" loading="lazy" style="width: 100%; height: 100%; object-fit: cover;">
+                    <img src="https://images.unsplash.com/photo-1609342122563-a43acbc32f5a?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Woman practicing online yoga at home on her laptop" loading="lazy" style="width: 100%; height: 100%; object-fit: cover;">
                 </div>
                 <div class="blog-content">
                     <div>
@@ -775,7 +775,7 @@
         <div class="featured-grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 30px;">
             <a href="yoga-for-beginners-at-home.html" class="blog-card featured-card" style="display: flex;">
                 <div class="blog-image">
-                    <img src="https://images.unsplash.com/photo-1544367567-0f2fcb009e0b?w=600&h=400&fit=crop" alt="Yoga practice" loading="lazy" style="width: 100%; height: 100%; object-fit: cover;">
+                    <img src="https://images.unsplash.com/photo-1574680096145-d05b474e2155?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Yoga practice" loading="lazy" style="width: 100%; height: 100%; object-fit: cover;">
                 </div>
                 <div class="blog-content">
                     <div class="blog-meta"><span class="blog-category">Beginner Tips</span></div>
@@ -786,7 +786,7 @@
             </a>
             <a href="metabolic-impact-of-cardio-dance-workouts.html" class="blog-card featured-card" style="display: flex;">
                 <div class="blog-image">
-                    <img src="https://images.unsplash.com/photo-1544367567-0f2fcb009e0b?w=600&h=400&fit=crop" alt="Yoga practice" loading="lazy" style="width: 100%; height: 100%; object-fit: cover;">
+                    <img src="https://images.unsplash.com/photo-1506126613657-233f4784d193?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Yoga practice" loading="lazy" style="width: 100%; height: 100%; object-fit: cover;">
                 </div>
                 <div class="blog-content">
                     <div class="blog-meta"><span class="blog-category">Dance Fitness</span></div>
@@ -797,7 +797,7 @@
             </a>
             <a href="/corporate-yoga-day-bangalore.html" class="blog-card featured-card" style="display: flex;">
                 <div class="blog-image">
-                    <img src="https://images.unsplash.com/photo-1544367567-0f2fcb009e0b?w=600&h=400&fit=crop" alt="Yoga practice" loading="lazy" style="width: 100%; height: 100%; object-fit: cover;">
+                    <img src="https://images.unsplash.com/photo-1600881333168-2ef49b341f30?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Yoga practice" loading="lazy" style="width: 100%; height: 100%; object-fit: cover;">
                 </div>
                 <div class="blog-content">
                     <div class="blog-meta"><span class="blog-category">Corporate Wellness</span></div>
@@ -866,7 +866,7 @@
             <!-- New Blog: Online Dance Fitness Classes India -->
             <a href="online-dance-fitness-classes-india.html" class="blog-card" data-category="dance-fitness">
                 <div class="blog-image">
-                    <img src="../assets/images/dance-workshop-team-building.jpg" alt="Live online dance fitness classes with Anusha" loading="lazy" style="width: 100%; height: 100%; object-fit: cover;">
+                    <img src="https://images.unsplash.com/photo-1603988314981-d1c0717208d9?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Live online dance fitness classes with Anusha" loading="lazy" style="width: 100%; height: 100%; object-fit: cover;">
                 </div>
                 <div class="blog-content">
                     <div>
@@ -885,7 +885,7 @@
             <!-- New Blog: Dance Fitness vs Gym -->
             <a href="dance-fitness-vs-gym-calories.html" class="blog-card" data-category="dance-fitness">
                 <div class="blog-image">
-                    <img src="../assets/images/dance-workshop-team-building.jpg" alt="Dance fitness group class vs traditional gym workout comparison" loading="lazy" style="width: 100%; height: 100%; object-fit: cover;">
+                    <img src="https://images.unsplash.com/photo-1508215885820-4585e56135c8?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Dance fitness group class vs traditional gym workout comparison" loading="lazy" style="width: 100%; height: 100%; object-fit: cover;">
                 </div>
                 <div class="blog-content">
                     <div>
@@ -904,7 +904,7 @@
             <!-- New Blog: Hatha Yoga Posture Correction -->
             <a href="biomechanics-online-hatha-yoga-desk-slouch.html" class="blog-card" data-category="online-yoga">
                 <div class="blog-image">
-                    <img src="https://images.unsplash.com/photo-1544367567-0f2fcb009e0b?w=600&h=400&fit=crop" alt="Yoga practice" loading="lazy" style="width: 100%; height: 100%; object-fit: cover;">
+                    <img src="https://images.unsplash.com/photo-1552072805-2a9039d00e57?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Yoga practice" loading="lazy" style="width: 100%; height: 100%; object-fit: cover;">
                 </div>
                 <div class="blog-content">
                     <div>
@@ -924,7 +924,7 @@
             <!-- New Blog: Virtual Fitness Dubai Corporate -->
             <a href="virtual-fitness-corporate-yoga-dubai.html" class="blog-card" data-category="online-yoga corporate">
                 <div class="blog-image">
-                    <img src="https://images.unsplash.com/photo-1544367567-0f2fcb009e0b?w=600&h=400&fit=crop" alt="Yoga practice" loading="lazy" style="width: 100%; height: 100%; object-fit: cover;">
+                    <img src="https://images.unsplash.com/photo-1545205597-3d9d02c29597?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Yoga practice" loading="lazy" style="width: 100%; height: 100%; object-fit: cover;">
                 </div>
                 <div class="blog-content">
                     <div>
@@ -1432,7 +1432,7 @@
             <!-- New Blog: Online Yoga for Indians in UK -->
             <a href="online-yoga-for-indians-in-uk.html" class="blog-card" data-category="online-yoga">
                 <div class="blog-image">
-                    <img loading="lazy" src="https://images.unsplash.com/photo-1571902943202-507ec2618e8f?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Indian woman doing yoga online from her home in the UK">
+                    <img loading="lazy" src="https://images.unsplash.com/photo-1620014073010-0969eb210217?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Indian woman doing yoga online from her home in the UK">
                 </div>
                 <div class="blog-content">
                     <div>
@@ -1450,7 +1450,7 @@
             <!-- New Blog: Corporate Yoga Day Bangalore -->
             <a href="https://zugafitness.in/corporate-yoga-day-bangalore.html" class="blog-card" data-category="online-yoga corporate">
                 <div class="blog-image">
-                    <img loading="lazy" src="https://images.unsplash.com/photo-1522071820081-009f0129c71c?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Corporate yoga session in a Bangalore office">
+                    <img loading="lazy" src="https://images.unsplash.com/photo-1600881333168-2ef49b341f30?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Corporate yoga session in a Bangalore office">
                 </div>
                 <div class="blog-content">
                     <div>
@@ -1504,7 +1504,7 @@
             <!-- New Blog: Pranayama for Anxiety -->
             <a href="pranayama-for-anxiety.html" class="blog-card" data-category="online-yoga">
                 <div class="blog-image">
-                    <img loading="lazy" src="https://images.unsplash.com/photo-1571902943202-507ec2618e8f?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Pranayama for Anxiety">
+                    <img loading="lazy" src="https://images.unsplash.com/photo-1510894347713-fc3ed6fdf539?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Pranayama for Anxiety">
                 </div>
                 <div class="blog-content">
                     <div>
@@ -1576,7 +1576,7 @@
             <!-- New Blog: Online Yoga Classes in Singapore -->
             <a href="online-yoga-classes-singapore-indian-community.html" class="blog-card" data-category="online-yoga">
                 <div class="blog-image">
-                    <img loading="lazy" src="https://images.unsplash.com/photo-1510894347713-fc3ad6cb03a8?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Online Yoga Classes Singapore Indian Community">
+                    <img loading="lazy" src="https://images.unsplash.com/photo-1524594152303-9fd13543fe6e?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Online Yoga Classes Singapore Indian Community">
                 </div>
                 <div class="blog-content">
                     <div>
@@ -1612,7 +1612,7 @@
             <!-- New Blog: Online Yoga Classes in Dubai -->
             <a href="online-yoga-classes-dubai-uae-indian-expats.html" class="blog-card" data-category="online-yoga">
                 <div class="blog-image">
-                    <img loading="lazy" src="https://images.unsplash.com/photo-1510894347713-fc3ad6cb03a8?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Online Yoga Classes Dubai UAE Indian Expats">
+                    <img loading="lazy" src="https://images.unsplash.com/photo-1588282322673-c31965a75c3e?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Online Yoga Classes Dubai UAE Indian Expats">
                 </div>
                 <div class="blog-content">
                     <div>
@@ -1630,7 +1630,7 @@
             <!-- New Blog: Online Yoga Classes in Canada -->
             <a href="online-yoga-classes-canada-vancouver-toronto.html" class="blog-card" data-category="online-yoga">
                 <div class="blog-image">
-                    <img loading="lazy" src="https://images.unsplash.com/photo-1510894347713-fc3ad6cb03a8?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Online Yoga Classes Canada Vancouver Toronto">
+                    <img loading="lazy" src="https://images.unsplash.com/photo-1552674605-db6ffd4facb5?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Online Yoga Classes Canada Vancouver Toronto">
                 </div>
                 <div class="blog-content">
                     <div>
@@ -1648,7 +1648,7 @@
             <!-- New Blog: Yoga Poses for PCOD -->
             <a href="yoga-poses-for-pcod-management.html" class="blog-card" data-category="online-yoga womens-health">
                 <div class="blog-image">
-                    <img loading="lazy" src="https://images.unsplash.com/photo-1571902943202-507ec2618e8f?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Yoga for PCOD management">
+                    <img loading="lazy" src="https://images.unsplash.com/photo-1548607996-7f289f1f7d19?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Yoga for PCOD management">
                 </div>
                 <div class="blog-content">
                     <div>
@@ -1666,7 +1666,7 @@
             <!-- New Blog: London Timezone -->
             <a href="live-online-yoga-class-london-timezone.html" class="blog-card" data-category="online-yoga">
                 <div class="blog-image">
-                    <img loading="lazy" src="https://images.unsplash.com/photo-1545208393-596371ba4a33?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Live Online Yoga London GMT">
+                    <img loading="lazy" src="https://images.unsplash.com/photo-1555252333-9f8e92e65df9?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Live Online Yoga London GMT">
                 </div>
                 <div class="blog-content">
                     <div>
@@ -1684,7 +1684,7 @@
             <!-- New Blog: Live vs Recorded -->
             <a href="live-vs-recorded-online-yoga-classes.html" class="blog-card" data-category="online-yoga">
                 <div class="blog-image">
-                    <img loading="lazy" src="https://images.unsplash.com/photo-1510894347713-fc3ad6cb03a8?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Live vs. Recorded Online Yoga">
+                    <img loading="lazy" src="https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Live vs. Recorded Online Yoga">
                 </div>
                 <div class="blog-content">
                     <div>

--- a/Blog/live-online-yoga-class-london-timezone.html
+++ b/Blog/live-online-yoga-class-london-timezone.html
@@ -585,7 +585,7 @@
   <meta property="og:description" content="London professionals — discover why timezone-compatible live online yoga classes beat pre-recorded videos. Zuga Fitness offers GMT-friendly live sessions with expert Indian instructors.">
   <meta property="og:url" content="https://zugafitness.in/Blog/live-online-yoga-class-london-timezone.html">
   <meta property="og:type" content="article">
-  <meta property="og:image" content="https://zugafitness.in/assets/images/zuga-logo.webp">
+  <meta property="og:image" content="https://images.unsplash.com/photo-1555252333-9f8e92e65df9?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80">
 
   <link rel="stylesheet" href="../assets/whatsapp.css">
 
@@ -660,7 +660,7 @@
         </div>
 
         <div class="featured-image">
-            <img loading="lazy" src="https://images.unsplash.com/photo-1545208393-596371ba4a33?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80" alt="Live online yoga class London GMT timezone">
+            <img loading="lazy" src="https://images.unsplash.com/photo-1555252333-9f8e92e65df9?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Live online yoga class London GMT timezone">
             <div class="image-caption">Practicing live yoga in your own timezone creates a stronger community connection.</div>
         </div>
 

--- a/Blog/live-vs-recorded-online-yoga-classes.html
+++ b/Blog/live-vs-recorded-online-yoga-classes.html
@@ -656,7 +656,7 @@
         </div>
 
         <div class="featured-image">
-            <img loading="lazy" src="https://images.unsplash.com/photo-1593164842264-854604db2260?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80" alt="Live online yoga class interaction">
+            <img loading="lazy" src="https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Live online yoga class interaction">
             <div class="image-caption">Interactive sessions bridge the gap between home practice and studio energy</div>
         </div>
 

--- a/Blog/metabolic-impact-of-cardio-dance-workouts.html
+++ b/Blog/metabolic-impact-of-cardio-dance-workouts.html
@@ -655,7 +655,7 @@
         </div>
 
         <div class="featured-image">
-            <img loading="lazy" src="https://images.unsplash.com/photo-1524594152303-9fd13543fe6e?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80" alt="High-energy cardio dance workout">
+            <img loading="lazy" src="https://images.unsplash.com/photo-1506126613657-233f4784d193?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="High-energy cardio dance workout">
             <div class="image-caption">High-energy dance sessions bridge the gap between fat loss and mental clarity</div>
         </div>
 

--- a/Blog/online-dance-fitness-classes-india.html
+++ b/Blog/online-dance-fitness-classes-india.html
@@ -647,7 +647,7 @@
         </div>
 
         <div class="featured-image">
-            <img loading="lazy" src="../assets/images/dance-workshop-team-building.jpg" alt="Live online dance fitness classes with Anusha">
+            <img loading="lazy" src="https://images.unsplash.com/photo-1603988314981-d1c0717208d9?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Live online dance fitness classes with Anusha">
             <div class="image-caption">Experience the energy of live Bollywood & Latin dance fitness from your living room</div>
         </div>
 

--- a/Blog/online-yoga-classes-canada-vancouver-toronto.html
+++ b/Blog/online-yoga-classes-canada-vancouver-toronto.html
@@ -585,7 +585,7 @@
   <meta property="og:description" content="Canada is the world's #1 yoga nation. Discover why Toronto & Vancouver professionals are choosing Zuga Fitness for live online yoga classes with authentic Indian instructors across EST & PST timezones.">
   <meta property="og:url" content="https://zugafitness.in/Blog/online-yoga-classes-canada-vancouver-toronto.html">
   <meta property="og:type" content="article">
-  <meta property="og:image" content="https://zugafitness.in/assets/images/zuga-logo.webp">
+  <meta property="og:image" content="https://images.unsplash.com/photo-1552674605-db6ffd4facb5?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80">
 
   <link rel="stylesheet" href="../assets/whatsapp.css">
 
@@ -660,7 +660,7 @@
         </div>
 
         <div class="featured-image">
-            <img loading="lazy" src="https://images.unsplash.com/photo-1524864919058-23d53d1679bc?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80" alt="Live online yoga class interaction">
+            <img loading="lazy" src="https://images.unsplash.com/photo-1552674605-db6ffd4facb5?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Live online yoga class interaction">
             <div class="image-caption">Interactive sessions bridge the gap between home practice and studio energy</div>
         </div>
 

--- a/Blog/online-yoga-classes-dubai-uae-indian-expats.html
+++ b/Blog/online-yoga-classes-dubai-uae-indian-expats.html
@@ -585,7 +585,7 @@
   <meta property="og:description" content="Over 3.5 million Indians call the UAE home. Discover why Dubai & Abu Dhabi expats choose Zuga Fitness for authentic live online yoga classes in the GST timezone.">
   <meta property="og:url" content="https://zugafitness.in/Blog/online-yoga-classes-dubai-uae-indian-expats.html">
   <meta property="og:type" content="article">
-  <meta property="og:image" content="https://zugafitness.in/assets/images/zuga-logo.webp">
+  <meta property="og:image" content="https://images.unsplash.com/photo-1588282322673-c31965a75c3e?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80">
 
   <link rel="stylesheet" href="../assets/whatsapp.css">
 
@@ -660,7 +660,7 @@
         </div>
 
         <div class="featured-image">
-            <img loading="lazy" src="https://images.unsplash.com/photo-1549576490-b0b4831ef60a?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80" alt="Online Yoga Classes in Dubai & UAE">
+            <img loading="lazy" src="https://images.unsplash.com/photo-1588282322673-c31965a75c3e?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Online Yoga Classes in Dubai & UAE">
             <div class="image-caption">Interactive sessions bridge the gap between home practice and studio energy</div>
         </div>
 

--- a/Blog/online-yoga-classes-singapore-indian-community.html
+++ b/Blog/online-yoga-classes-singapore-indian-community.html
@@ -585,7 +585,7 @@
   <meta property="og:description" content="Singapore ranks #2 globally for yoga interest. Discover why 350,000 Indian expats in Singapore choose Zuga Fitness for live online yoga classes in the SGT timezone with authentic Indian instructors.">
   <meta property="og:url" content="https://zugafitness.in/Blog/online-yoga-classes-singapore-indian-community.html">
   <meta property="og:type" content="article">
-  <meta property="og:image" content="https://zugafitness.in/assets/images/zuga-logo.webp">
+  <meta property="og:image" content="https://images.unsplash.com/photo-1524594152303-9fd13543fe6e?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80">
 
   <link rel="stylesheet" href="../assets/whatsapp.css">
 
@@ -660,7 +660,7 @@
         </div>
 
         <div class="featured-image">
-            <img loading="lazy" src="https://images.unsplash.com/photo-1510894347713-fc3ad6cb03a8?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80" alt="Online Yoga Classes Singapore Indian Community">
+            <img loading="lazy" src="https://images.unsplash.com/photo-1524594152303-9fd13543fe6e?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Online Yoga Classes Singapore Indian Community">
             <div class="image-caption">Live interactive sessions bring authentic Indian yoga directly to Singaporean homes</div>
         </div>
 

--- a/Blog/online-yoga-for-indians-in-uk.html
+++ b/Blog/online-yoga-for-indians-in-uk.html
@@ -13,7 +13,7 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:title" content="Online Yoga Classes for Indians in the UK — Live, Not Recorded | Zuga Fitness">
     <meta property="og:description" content="Missing your yoga practice in the UK? Zuga Fitness runs live online yoga classes in GMT timezone — taught by Indian instructors who understand your practice.">
-    <meta property="og:image" content="https://images.unsplash.com/photo-1506126613408-eca07ce68773?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80">
+    <meta property="og:image" content="https://images.unsplash.com/photo-1620014073010-0969eb210217?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80">
     <meta property="og:url" content="https://zugafitness.in/Blog/online-yoga-for-indians-in-uk.html">
     <meta property="og:type" content="article">
 
@@ -21,7 +21,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Online Yoga Classes for Indians in the UK — Live, Not Recorded">
     <meta name="twitter:description" content="Missing your yoga practice in the UK? Zuga Fitness runs live online yoga classes in GMT timezone — taught by Indian instructors who understand your practice.">
-    <meta name="twitter:image" content="https://images.unsplash.com/photo-1506126613408-eca07ce68773?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80">
+    <meta name="twitter:image" content="https://images.unsplash.com/photo-1620014073010-0969eb210217?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80">
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
@@ -663,7 +663,7 @@
         </div>
 
         <div class="featured-image">
-            <img loading="lazy" src="https://images.unsplash.com/photo-1506126613408-eca07ce68773?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80" alt="Indian woman doing yoga online from her home in the UK">
+            <img loading="lazy" src="https://images.unsplash.com/photo-1620014073010-0969eb210217?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Indian woman doing yoga online from her home in the UK">
             <div class="image-caption">Zuga Fitness runs live yoga classes in GMT timezone for the Indian diaspora in the UK</div>
         </div>
 

--- a/Blog/pranayama-for-anxiety.html
+++ b/Blog/pranayama-for-anxiety.html
@@ -586,7 +586,7 @@
   <meta property="og:url" content="https://zugafitness.in/Blog/pranayama-for-anxiety.html">
   <meta property="og:title" content="Pranayama for Anxiety: 5 Breathing Techniques That Calm Your Mind in Minutes | Zuga Fitness">
   <meta property="og:description" content="5 pranayama breathing techniques that calm anxiety in minutes. Live online classes with real-time guidance. Free trial available.">
-  <meta property="og:image" content="https://images.unsplash.com/photo-1506126613408-eca07ce68773?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80">
+  <meta property="og:image" content="https://images.unsplash.com/photo-1510894347713-fc3ed6fdf539?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80">
   <meta property="og:site_name" content="Zuga Fitness">
 
   <!-- Twitter -->
@@ -594,7 +594,7 @@
   <meta name="twitter:url" content="https://zugafitness.in/Blog/pranayama-for-anxiety.html">
   <meta name="twitter:title" content="Pranayama for Anxiety: 5 Breathing Techniques That Calm Your Mind in Minutes | Zuga Fitness">
   <meta name="twitter:description" content="5 pranayama breathing techniques that calm anxiety in minutes. Live online classes with real-time guidance. Free trial available.">
-  <meta name="twitter:image" content="https://images.unsplash.com/photo-1506126613408-eca07ce68773?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80">
+  <meta name="twitter:image" content="https://images.unsplash.com/photo-1510894347713-fc3ed6fdf539?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80">
 
   <link rel="stylesheet" href="../assets/whatsapp.css">
 
@@ -666,7 +666,7 @@
         </div>
 
         <div class="featured-image">
-            <img loading="lazy" src="https://images.unsplash.com/photo-1506126613408-eca07ce68773?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80" alt="Pranayama breathing techniques for anxiety">
+            <img loading="lazy" src="https://images.unsplash.com/photo-1510894347713-fc3ed6fdf539?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Pranayama breathing techniques for anxiety">
             <div class="image-caption">Breathwork provides an immediate tool to calm the nervous system</div>
         </div>
 

--- a/Blog/yoga-for-beginners-at-home.html
+++ b/Blog/yoga-for-beginners-at-home.html
@@ -585,14 +585,14 @@
 
   <!-- Open Graph / Facebook -->
   <meta property="og:title" content="Yoga for Beginners at Home: How to Start (And Actually Stick With It) | Zuga Fitness">
-    <meta property="og:image" content="https://images.unsplash.com/photo-1510894347713-fc3ed6fdf539?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80">
+    <meta property="og:image" content="https://images.unsplash.com/photo-1574680096145-d05b474e2155?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80">
   <meta property="og:url" content="https://zugafitness.in/Blog/yoga-for-beginners-at-home.html">
   <meta property="og:type" content="article">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Yoga for Beginners at Home: How to Start (And Actually Stick With It)">
-    <meta name="twitter:image" content="https://images.unsplash.com/photo-1510894347713-fc3ed6fdf539?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80">
+    <meta name="twitter:image" content="https://images.unsplash.com/photo-1574680096145-d05b474e2155?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80">
 
   <link rel="stylesheet" href="../assets/whatsapp.css">
 
@@ -661,7 +661,7 @@
         </div>
 
         <div class="featured-image">
-            <img loading="lazy" src="https://images.unsplash.com/photo-1510894347713-fc3ed6fdf539?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80" alt="Beginner doing yoga at home on a mat in a bright living room">
+            <img loading="lazy" src="https://images.unsplash.com/photo-1574680096145-d05b474e2155?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Beginner doing yoga at home on a mat in a bright living room">
             <div class="image-caption">Starting yoga at home is easier than most beginners think — with the right guidance</div>
         </div>
 

--- a/Blog/yoga-poses-for-pcod-management.html
+++ b/Blog/yoga-poses-for-pcod-management.html
@@ -13,7 +13,7 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:title" content="7 Best Yoga Poses for PCOD: Reduce Symptoms Naturally | Zuga Fitness">
     <meta property="og:description" content="7 best yoga poses for PCOD management at home. Regulate hormones & reduce symptoms with live expert-led sessions. Free trial available.">
-    <meta property="og:image" content="https://images.unsplash.com/photo-1506126613408-eca07ce68773?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80">
+    <meta property="og:image" content="https://images.unsplash.com/photo-1548607996-7f289f1f7d19?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80">
     <meta property="og:url" content="https://zugafitness.in/Blog/yoga-poses-for-pcod-management.html">
     <meta property="og:type" content="article">
 
@@ -21,7 +21,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="7 Best Yoga Poses for PCOD: Reduce Symptoms Naturally | Zuga Fitness">
     <meta name="twitter:description" content="7 best yoga poses for PCOD management at home. Regulate hormones & reduce symptoms with live expert-led sessions. Free trial available.">
-    <meta name="twitter:image" content="https://images.unsplash.com/photo-1506126613408-eca07ce68773?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80">
+    <meta name="twitter:image" content="https://images.unsplash.com/photo-1548607996-7f289f1f7d19?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80">
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
@@ -664,7 +664,7 @@
         </div>
 
         <div class="featured-image">
-            <img loading="lazy" src="https://images.unsplash.com/photo-1593810450967-f9c42742e326?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80" alt="Yoga for PCOD management">
+            <img loading="lazy" src="https://images.unsplash.com/photo-1548607996-7f289f1f7d19?ixlib=rb-4.0.3&auto=format&fit=crop&w=900&q=80" alt="Yoga for PCOD management">
             <div class="image-caption">Targeted yoga poses can help regulate hormones and manage PCOD symptoms effectively</div>
         </div>
 


### PR DESCRIPTION
Resolves issue where identical images were repeated across different blogs in the `Blog/index.html` list and inside the blogs themselves. 

I've ensured every duplicated post gets a unique, royalty-free image from Unsplash. Furthermore, I made sure this didn't accidentally overwrite the "Related Articles" thumbnails at the bottom of blog pages by precisely targeting the hero image and Open Graph metadata (`og:image`, `twitter:image`). All tests passed and Playwright verification showed exactly what was expected.

---
*PR created automatically by Jules for task [150617883625008606](https://jules.google.com/task/150617883625008606) started by @ZugaFitness*